### PR TITLE
Upgrade Nokogiri due to CVE-2018-8048.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,7 +326,7 @@ GEM
     minitest (5.9.1)
     multi_json (1.13.1)
     nenv (0.3.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)


### PR DESCRIPTION
See: https://github.com/sparklemotion/nokogiri/pull/1746