### PR TITLE
Remove Starter plan Portfolio Sharing text – wrong in NZ only.

### DIFF
--- a/data/plans/nz.json
+++ b/data/plans/nz.json
@@ -4,12 +4,7 @@
   },
   {
     "label": "Starter",
-    "price": 15,
-
-    "info": [
-      "**Everything in Free** plus",
-      "Portfolio Sharing"
-    ]
+    "price": 15
   },
   {
     "label": "Investor",


### PR DESCRIPTION
[ticket](https://vimaly.com/#j8mqm/t/www_NZ_Pricing_page_-_portfolio_sharing_discrepanc.../tVrsVxA8q47SaPY5E)