### PR TITLE
Ensure that priority is numeric and fallback to 0 otherwise.

### DIFF
--- a/helpers/partner_helper.rb
+++ b/helpers/partner_helper.rb
@@ -12,8 +12,8 @@ module PartnerHelper
   end
 
   def self.sort_partners(a, b)
-    a_priority = (a[:priority] || 0)
-    b_priority = (b[:priority] || 0)
+    a_priority = a[:priority].is_a?(Numeric) && a[:priority] || 0 # can be invalid...
+    b_priority = b[:priority].is_a?(Numeric) && b[:priority] || 0 # can be invalid...
     return (a[:name] || '')&.strip&.downcase <=> (b[:name] || '')&.strip&.downcase if b_priority == a_priority
     return b_priority <=> a_priority
   end


### PR DESCRIPTION
Unfortunately, priority wound up being calculated to a Hash: `{ en-NZ: 0 }` because it did not have a default (`en`) locale.  This is kind of an issue with Contentful's UI and the `localize_entry` code...