### PR TITLE
Update Nokoogiri to 1.8.5 for CVE-2018-14404

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,7 +326,7 @@ GEM
     minitest (5.9.1)
     multi_json (1.13.1)
     nenv (0.3.0)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)


### PR DESCRIPTION
[ticket](https://vimaly.com/#j8mqm/t/CVE-2018-14404_Update_nokogiri_gem/czhN1dLCtIJxprFzE)