### PR TITLE
Make page content and test string comparable

### DIFF
--- a/spec/features/landing_pages_page_spec.rb
+++ b/spec/features/landing_pages_page_spec.rb
@@ -87,11 +87,27 @@ describe 'Landing Pages Pages', :type => :feature do
     expect(page).to have_text(string) if testable?(string)
   end
 
+  # kramdown converts certain ASCII characters into typographic symbols
+  # see https://kramdown.gettalong.org/syntax.html#typographic-symbols
+  # we have to do the same
   def normalised(string)
     return unless string
 
+    # single quotes
     string = string.gsub(/'/, '’')
+    # double quotes
+    string = string.gsub(/"/, '“')
+    # ellipsis
     string = string.gsub(/\.\.\./, '…')
+    # em-dash
+    string = string.gsub(/---/, '—')
+    # en-dash
+    string = string.gsub(/--/, '–')
+    # left guillemet
+    string = string.gsub(/<</, '«')
+    # right guillemet
+    string = string.gsub(/>>/, '»')
+
     string
   end
 


### PR DESCRIPTION
See [bug ticket](https://vimaly.com/#j8mqm/t/landing_pages_Problems_with_the_tests_and_smart_ch.../DKo6ASfc6VA16AA71) for details.

**Background**
The markdown processor used by _middleman_, namely [kramdown](https://kramdown.gettalong.org), converts certain ASCII characters into [typographic symbols](https://kramdown.gettalong.org/syntax.html#typographic-symbols). For example, three dots `...` are converted to an ellipse `…`.