### PR TITLE
Remove autoLinker in GA script.

### DIFF
--- a/source/layouts/partials/_analytics_js.html.erb
+++ b/source/layouts/partials/_analytics_js.html.erb
@@ -28,7 +28,7 @@
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      ga('create', '<%= ApplicationConfig::GoogleAnalytics::TRACKING_KEY %>', 'auto', {allowLinker: true});
+      ga('create', '<%= ApplicationConfig::GoogleAnalytics::TRACKING_KEY %>', 'auto');
       ga('require', '<%= ApplicationConfig::GoogleAnalytics::OPTIMIZE_CONTAINER %>');
     </script>
   <% end %>


### PR DESCRIPTION
[ticket](https://vimaly.com/#j8mqm/t/www_Remove_autoLinker_config_in_Google_Optimize_sn.../MR77nkzTXtKMYc1M9)

Appears to be for multiple domains, which we don't do.  It seems to be causing some minor errors in Google Optimize validation..

https://support.google.com/analytics/answer/1034342?hl=en