### PR TITLE
Remove the opacity on the orange notice.

### DIFF
--- a/source/css/components/_notice.scss
+++ b/source/css/components/_notice.scss
@@ -10,7 +10,7 @@
   }
 
   &, &--secondary {
-    background-color: rgba($colour_secondary, .95);
+    background-color: $colour_secondary;
     color: $colour_pro;
   }
 


### PR DESCRIPTION
[ticket](https://vimaly.com/#j8mqm/t/www_investigate_Remove_Notice_opacity_fixes_orang.../dC7h16VJB2Qz1keol)

Angela was very confused by wrong oranges – a lot of it is just a bad color picker, but this was also off.