### PR TITLE
Ignore testing Landing Page contents with gt/lt symbols.

### DIFF
--- a/spec/features/landing_pages_page_spec.rb
+++ b/spec/features/landing_pages_page_spec.rb
@@ -104,7 +104,7 @@ describe 'Landing Pages Pages', :type => :feature do
     return false unless string
 
     # this could be markdown, we don't test it then
-    return false if string.match(/[\*\_\~\-\#]+/)
+    return false if string.match(/[\*\_\~\-\#\<\>]+/)
 
     true
   end


### PR DESCRIPTION
This will mean `5 > 1` will not be testable, but it's probably not worth a gigantic regex here to properly detect HTML.

So if we create a landing page with a text like `<sup>1</sup> hello world`, it just ignores it and doesn't test that exists.

Stemming from error:
https://travis-ci.org/sharesight/www.sharesight.com/jobs/554477878