### PR TITLE
Throw better error on landing page missing localization

### DIFF
--- a/spec/features/landing_pages_page_spec.rb
+++ b/spec/features/landing_pages_page_spec.rb
@@ -72,6 +72,9 @@ describe 'Landing Pages Pages', :type => :feature do
   end
 
   def expect_page_text(string)
+    return unless string
+    raise "Found invalid page text: '#{string.inspect}' of class '#{string.class}'" unless string.is_a?(String)
+
     string = normalised(string)
     expect(page).to have_text(string) if testable?(string)
   end

--- a/spec/features/landing_pages_page_spec.rb
+++ b/spec/features/landing_pages_page_spec.rb
@@ -83,19 +83,19 @@ describe 'Landing Pages Pages', :type => :feature do
     return unless string
 
     # single quotes
-    string = string&.gsub(/'/, '’')
+    string = string.gsub(/'/, '’')
     # double quotes
-    string = string&.gsub(/"/, '“')
+    string = string.gsub(/"/, '“')
     # ellipsis
-    string = string&.gsub(/\.\.\./, '…')
+    string = string.gsub(/\.\.\./, '…')
     # em-dash
-    string = string&.gsub(/---/, '—')
+    string = string.gsub(/---/, '—')
     # en-dash
-    string = string&.gsub(/--/, '–')
+    string = string.gsub(/--/, '–')
     # left guillemet
-    string = string&.gsub(/<</, '«')
+    string = string.gsub(/<</, '«')
     # right guillemet
-    string = string&.gsub(/>>/, '»')
+    string = string.gsub(/>>/, '»')
 
     string
   end
@@ -104,7 +104,7 @@ describe 'Landing Pages Pages', :type => :feature do
     return false unless string
 
     # this could be markdown, we don't test it then
-    return false if string&.match(/[\*\_\~\-\#\<\>]+/)
+    return false if string.match(/[\*\_\~\-\#\<\>]+/)
 
     true
   end


### PR DESCRIPTION
[ticket](https://vimaly.com/#j8mqm/t/wwwlanding_pages_AU_code_appearing_on_non-AU_pages/3kfcVUgGbv60LP5SZ)

The cause is from Contentful.  Our version of Middleman + Contentful doesn't seem to support localization without a default locale.  I vaguely recall this issue, not sure if I fixed it or not.  I had put a few PRs into the gem we use, but we're on such an old version now that it's not worth going back and looking..

Excerpts are from data file `data/landing-pages/pages/3YDWBtkMQJyfIiZIdY7rk4.yaml`

```
    :text:
      :en-AU: "<small><sup>1</sup>If you are an Australian tax resident and you derive
        income from the sharemarket, your Sharesight subscription may be tax deductible.
        Check with your accountant for details.</small>"
```

I manually added a space in Contentful, so this is now:
```
    :text:
      :en: " "
      :en-AU: "<small><sup>1</sup>If you are an Australian tax resident and you derive
        income from the sharemarket, your Sharesight subscription may be tax deductible.
        Check with your accountant for details.</small>"
```