### PR TITLE
Fix test around Campaign Code Cookie rendering.

### DIFF
--- a/source/partials/_campaign_code_cookie.html.erb
+++ b/source/partials/_campaign_code_cookie.html.erb
@@ -1,11 +1,11 @@
-<% if locals[:campaign_code_cookie] %>
+<% unless locals[:campaign_code_cookie].blank? %>
   <script id="campaign_code_cookie">
      (function () {
        const d = new Date();
        d.setTime(d.getTime() + (30*24*60*60*1000)); // 30 days
 
        try {
-         let cookie = `campaign_code=${encodeURIComponent(`<%= locals[:campaign_code_cookie] %>`)};`
+         let cookie = `campaign_code=${encodeURIComponent(`<%= locals[:campaign_code_cookie].html_safe %>`)};`
          cookie += `domain=.sharesight.com;`
          cookie += `path=/;`
          cookie += `expires=${d.toUTCString()};`;

--- a/spec/features/landing_pages_page_spec.rb
+++ b/spec/features/landing_pages_page_spec.rb
@@ -21,10 +21,11 @@ describe 'Landing Pages Pages', :type => :feature do
   private
 
   def expect_campaign_code_cookie(page, landing_page)
-    if landing_page[:campaign_code_cookie]
-      expect(page).to have_css('script#campaign_code_cookie')
+    unless landing_page[:campaign_code_cookie].blank?
+      expect(page).to have_selector('script#campaign_code_cookie', visible: :all)
+      expect(page.html).to include(landing_page[:campaign_code_cookie].html_safe)
     else
-      expect(page).not_to have_css('script#campaign_code_cookie')
+      expect(page).not_to have_selector('script#campaign_code_cookie', visible: :all)
     end
   end
 


### PR DESCRIPTION
Following [ticket](https://vimaly.com/#j8mqm/t/investapp_Read_a_Global_Cookie_from_www_for_Affili.../zMPLDkri3HOek6oOV) – see comments for issue.

 - Fix assertions. `script` is not a visible element, so it failed regardless here.  We never had published articles, so I believe this never actually got tested with Travis?
 - Might as well use `html_safe` while we're here.
 - Use `.blank?` for completeness.