### PR TITLE
Fix campaign code cookie in older browser (IE11).

### DIFF
--- a/source/partials/_campaign_code_cookie.html.erb
+++ b/source/partials/_campaign_code_cookie.html.erb
@@ -1,11 +1,11 @@
 <% unless locals[:campaign_code_cookie].blank? %>
   <script id="campaign_code_cookie">
      (function () {
-       const d = new Date();
+       var d = new Date();
        d.setTime(d.getTime() + (30*24*60*60*1000)); // 30 days
 
        try {
-         let cookie = 'campaign_code=' + encodeURIComponent("<%= locals[:campaign_code_cookie].html_safe %>");
+         var cookie = 'campaign_code=' + encodeURIComponent("<%= locals[:campaign_code_cookie].html_safe %>");
          cookie += ';domain=.sharesight.com';
          cookie += ';path=/';
          cookie += ';expires=' + d.toUTCString();

--- a/source/partials/_campaign_code_cookie.html.erb
+++ b/source/partials/_campaign_code_cookie.html.erb
@@ -5,14 +5,14 @@
        d.setTime(d.getTime() + (30*24*60*60*1000)); // 30 days
 
        try {
-         let cookie = `campaign_code=${encodeURIComponent(`<%= locals[:campaign_code_cookie].html_safe %>`)};`
-         cookie += `domain=.sharesight.com;`
-         cookie += `path=/;`
-         cookie += `expires=${d.toUTCString()};`;
+         let cookie = 'campaign_code=' + encodeURIComponent("<%= locals[:campaign_code_cookie].html_safe %>");
+         cookie += ';domain=.sharesight.com';
+         cookie += ';path=/';
+         cookie += ';expires=' + d.toUTCString();
 
          document.cookie = cookie;
        } catch (error) {
-         console.error(`Unable to set a campaign code for this landing page.`, error)
+         console.error('Unable to set a campaign code for this landing page.', error)
        }
      })();
   </script>


### PR DESCRIPTION
[ticket](https://vimaly.com/#j8mqm/t/www_Unexpected_Character_on_Landing_Page_Campaign_.../Ii64cGsdWyn3JS8HU)

A tilde is an unexpected character in a lot of browsers and this is inline code, does not get ran through Babel.