### PR TITLE
Remove 30 day trial and pricing text from Xero page.

### DIFF
--- a/source/partials/xero_faqs/_how_much_does_cashbook_cost.erb
+++ b/source/partials/xero_faqs/_how_much_does_cashbook_cost.erb
@@ -3,6 +3,6 @@
 </p>
 <ol>
   <li><a href="<%= config[:login_url] %>" title="Login to Sharesight">Login</a> to your Sharesight account (or <a href="<%= config[:signup_url] %>" title="Sign up for Sharesight">sign-up</a> for a new account).</li>
-  <li>Upgrade to a Sharesight Investor plan.</li>
+  <li>Upgrade to a Sharesight Investor or Expert plan.</li>
   <li>Add Xero Cashbook to your account - it’s free for 30 days, then $15/month per Cashbook account that you wish to connect to a Sharesight portfolio. The charge for your Cashbook account(s) will be included on your monthly or annual Sharesight invoices.</li>
 </ol>

--- a/source/partials/xero_faqs/_how_much_does_cashbook_cost.erb
+++ b/source/partials/xero_faqs/_how_much_does_cashbook_cost.erb
@@ -3,6 +3,6 @@
 </p>
 <ol>
   <li><a href="<%= config[:login_url] %>" title="Login to Sharesight">Login</a> to your Sharesight account (or <a href="<%= config[:signup_url] %>" title="Sign up for Sharesight">sign-up</a> for a new account).</li>
-  <li>Upgrade to a Sharesight Investor plan - it’s free for 30 days and $25/month after that.</li>
+  <li>Upgrade to a Sharesight Investor plan.</li>
   <li>Add Xero Cashbook to your account - it’s free for 30 days, then $15/month per Cashbook account that you wish to connect to a Sharesight portfolio. The charge for your Cashbook account(s) will be included on your monthly or annual Sharesight invoices.</li>
 </ol>


### PR DESCRIPTION
[ticket](https://vimaly.com/#j8mqm/t/WWWXero_Remove_30-day_trial_reference/KlphgxBTdTiTSzUzX)

Maintaining this text just isn't reasonable as it's hardcoded.