### PR TITLE
Deal with CVE-2019-16892

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -374,7 +374,7 @@ GEM
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
     ruby-progressbar (1.8.1)
-    rubyzip (1.2.2)
+    rubyzip (1.3.0)
     sass (3.4.22)
     selenium-webdriver (2.53.4)
       childprocess (~> 0.5)
@@ -442,4 +442,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.16.2
+   1.16.6


### PR DESCRIPTION
update rubyzip to safe version