### PR TITLE
Target `deployment-status` action version.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
     # -------- Deploy to S3 ++ Notify Bugsnag and Github Deployment of Status
     - name: Update deployment status to pending
       # NOTE: Only for deployment events, not commits/etc (which don't have an external deployment context)
-      uses: 'deliverybot/deployment-status@master'
+      uses: 'deliverybot/deployment-status@v1'
       if: github.event_name == 'deployment' && success() && steps.env.outputs.should_deploy == 'true'
       with:
         state: 'pending'
@@ -119,14 +119,14 @@ jobs:
     - name: Update deployment status to success
       # NOTE: Only for deployment events, not commits/etc (which don't have an external deployment context)
       if:  github.event_name == 'deployment' && success() && steps.env.outputs.should_deploy == 'true'
-      uses: 'deliverybot/deployment-status@master'
+      uses: 'deliverybot/deployment-status@v1'
       with:
         state: 'success'
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Update deployment status to failure
       # NOTE: Only for deployment events, not commits/etc (which don't have an external deployment context)
       if:  github.event_name == 'deployment' && failure() && steps.env.outputs.should_deploy == 'true'
-      uses: 'deliverybot/deployment-status@master'
+      uses: 'deliverybot/deployment-status@v1'
       with:
         state: 'failure'
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,7 +134,7 @@ jobs:
 
     # -------- Slack Notifications (different for test vs. deploy).
     - name: Send Deploy Notification
-      uses: homoluctus/slatify@master
+      uses: homoluctus/slatify@v1.8.0
       if: steps.env.outputs.should_deploy == 'true' && always()
       with:
         type: ${{ job.status }}
@@ -143,7 +143,7 @@ jobs:
         icon_emoji: ':rocket:'
         url: ${{ secrets.SLACK_WEBHOOK_URL }}
     - name: Send Test Failed Notification
-      uses: homoluctus/slatify@master
+      uses: homoluctus/slatify@v1.8.0
       if: steps.env.outputs.should_deploy == 'false' && failure()
       with:
         type: ${{ job.status }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
     # -------- Deploy to S3 ++ Notify Bugsnag and Github Deployment of Status
     - name: Update deployment status to pending
       # NOTE: Only for deployment events, not commits/etc (which don't have an external deployment context)
-      uses: 'deliverybot/deployment-status@v1'
+      uses: 'deliverybot/deployment-status@v1.0.0'
       if: github.event_name == 'deployment' && success() && steps.env.outputs.should_deploy == 'true'
       with:
         state: 'pending'
@@ -119,14 +119,14 @@ jobs:
     - name: Update deployment status to success
       # NOTE: Only for deployment events, not commits/etc (which don't have an external deployment context)
       if:  github.event_name == 'deployment' && success() && steps.env.outputs.should_deploy == 'true'
-      uses: 'deliverybot/deployment-status@v1'
+      uses: 'deliverybot/deployment-status@v1.0.0'
       with:
         state: 'success'
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Update deployment status to failure
       # NOTE: Only for deployment events, not commits/etc (which don't have an external deployment context)
       if:  github.event_name == 'deployment' && failure() && steps.env.outputs.should_deploy == 'true'
-      uses: 'deliverybot/deployment-status@v1'
+      uses: 'deliverybot/deployment-status@v1.0.0'
       with:
         state: 'failure'
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit https://github.com/deliverybot/deployment-status/commit/29aa7e9fd44181bb22fd5bc6778a96b1f42fc4af is broken on master (clearly untested), so let's target a version given `@master` is broken and they haven't push it into a release yet.