### PR TITLE
Lambda runtime update and add security headers

### DIFF
--- a/lambda/README.md
+++ b/lambda/README.md
@@ -14,7 +14,7 @@
   - Run `yarn jest`.
 
 ## Deployment
-  - Always run these steps on the `develop` branch when testing. There could be multiple testing versions of this lambda file around and you should always work with the merged copy, not your own copy, when modifying staging.
+  - Merge your changes to the `develop` branch before running this steps. There could be multiple testing versions of this lambda file around and you should always work with the merged copy, not your own copy, when modifying staging.
   - Test code changes first via `yarn jest` and improve `./localizationLambda.jest.js` whenever you make changes!
   - Visit the [Lambda](https://console.aws.amazon.com/lambda/home?region=us-east-1#/functions/localizeCloudfrontResponse/versions/$LATEST)
   - Paste the contents of `./localizationLambda.js` into the code section of `$LATEST`.

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -14,7 +14,7 @@
   - Run `yarn jest`.
 
 ## Deployment
-  - Always run these steps on the `develop` branch.  There could be multiple testing versions of this lambda file around and you should always work with the merged copy, not your own copy, when modifying staging.
+  - Always run these steps on the `develop` branch when testing. There could be multiple testing versions of this lambda file around and you should always work with the merged copy, not your own copy, when modifying staging.
   - Test code changes first via `yarn jest` and improve `./localizationLambda.jest.js` whenever you make changes!
   - Visit the [Lambda](https://console.aws.amazon.com/lambda/home?region=us-east-1#/functions/localizeCloudfrontResponse/versions/$LATEST)
   - Paste the contents of `./localizationLambda.js` into the code section of `$LATEST`.

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -2,7 +2,7 @@
 
 ## WARNING
 #### AWS May change!
- - The version of Node AWS offers currently (v6.10) is no longer in LTS.
+ - The version of Node AWS offers currently (v10.x) is no longer in LTS.
  - Their UI has changed and may continue to change, these instructions may become out of date quickly.
  - As of current writing, some of the Examples and screenshots in their own documentation are incorrect and do not match reality.
  - Lambdas are pretty young.  Lambda + Cloudfront is only out of preview in the past 6 months and the origin response type we're using is even newer than that.

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -1,4 +1,4 @@
-# Cloudfront + Lambda for localization
+# Cloudfront + Lambda for localization and security headers
 
 ## WARNING
 #### AWS May change!
@@ -9,6 +9,7 @@
 
 ## Why
   - We want to serve users their localized content.
+  - We want to include security headers to static website response.
 
 ## Tests
   - Run `yarn jest`.

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -14,7 +14,7 @@
   - Run `yarn jest`.
 
 ## Deployment
-  - Merge your changes to the `develop` branch before running this steps. There could be multiple testing versions of this lambda file around and you should always work with the merged copy, not your own copy, when modifying staging.
+  - Merge your changes to the `develop` branch before running these steps. There could be multiple testing versions of this lambda file around and you should always work with the merged copy, not your own copy, when modifying staging.
   - Test code changes first via `yarn jest` and improve `./localizationLambda.jest.js` whenever you make changes!
   - Visit the [Lambda](https://console.aws.amazon.com/lambda/home?region=us-east-1#/functions/localizeCloudfrontResponse/versions/$LATEST)
   - Paste the contents of `./localizationLambda.js` into the code section of `$LATEST`.

--- a/lambda/localizationLambda.js
+++ b/lambda/localizationLambda.js
@@ -10,7 +10,7 @@
  * If you are viewing this file inside of AWS, this code comes from https://github.com/sharesight/www.sharesight.com/.
  */
 
-const version = '7';
+const version = '8';
 const validCountryCodes = { global: '', au: 'au', ca: 'ca', nz: 'nz', gb: 'uk', uk: 'uk' };
 const validCountryCodesLength = Object.keys(validCountryCodes).length; // cache this
 

--- a/lambda/localizationLambda.js
+++ b/lambda/localizationLambda.js
@@ -10,7 +10,7 @@
  * If you are viewing this file inside of AWS, this code comes from https://github.com/sharesight/www.sharesight.com/.
  */
 
-const version = '5';
+const version = '7';
 const validCountryCodes = { global: '', au: 'au', ca: 'ca', nz: 'nz', gb: 'uk', uk: 'uk' };
 const validCountryCodesLength = Object.keys(validCountryCodes).length; // cache this
 

--- a/lambda/localizationLambda.js
+++ b/lambda/localizationLambda.js
@@ -10,7 +10,7 @@
  * If you are viewing this file inside of AWS, this code comes from https://github.com/sharesight/www.sharesight.com/.
  */
 
-const version = '8';
+const version = '9';
 const validCountryCodes = { global: '', au: 'au', ca: 'ca', nz: 'nz', gb: 'uk', uk: 'uk' };
 const validCountryCodesLength = Object.keys(validCountryCodes).length; // cache this
 

--- a/lambda/localizationLambda.js
+++ b/lambda/localizationLambda.js
@@ -96,9 +96,15 @@ function pathWithoutCountryCode (path) {
   return path;
 }
 
+function getStrictTransportSecurityHeader () {
+  return [{key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubdomains; preload'}];
+}
+
 const handler = function (event, context, callback) {
     const request = event.Records[0].cf.request;
     const response = event.Records[0].cf.response;
+
+    response.headers['strict-transport-security'] = getStrictTransportSecurityHeader();
 
     // if we don't want to localize the url, eg. Blogs
     for (let i=0; i < dontProcessLength; i++) {
@@ -169,6 +175,7 @@ module.exports = {
   getPathCountryCode: getPathCountryCode,
   getHeaderCountryCode: getHeaderCountryCode,
   getCookieCountryCode: getCookieCountryCode,
+  getStrictTransportSecurityHeader: getStrictTransportSecurityHeader,
   pathWithoutCountryCode: pathWithoutCountryCode,
   handler: handler,
 };

--- a/lambda/localizationLambda.js
+++ b/lambda/localizationLambda.js
@@ -1,13 +1,13 @@
 'use strict';
 
 /*
- * NOTE: This is an ORIGIN RESPONSE Lambda running on Node v6.10.
- * If the Node version changes, this code may need major refactor.
+ * NOTE: This is an ORIGIN RESPONSE Lambda running on Node v10.x
  * It takes a request + response and returns a response.
  * When we should redirect, the response is a 302 in the case of "We found the proper locale for you", in all other cases it simply returns the response you were meant to have.
+ * This lambda function includes `strict-transport-security` headers to all responses.
  *
  * This must be deployed *MANUALLY*.  See `../lambda/README.md`.
- * If you are viewing this file inside of AWS, this code comes from https://github.com/sharesight/www.sharesight.com/.
+ * If you are viewing this file inside of AWS, this code comes from the `lambda` folder on https://github.com/sharesight/www.sharesight.com/.
  */
 
 const version = '9';


### PR DESCRIPTION
Start by updating Node.js to latest version available on lambda@edge, which is 10.x, and making sure update worked as expected.
Then add the `Strict-Transport-Security` headers as per [this ticket](https://vimaly.com/#j8mqm/t/implement_Strict-Transport-Security_headers./8QoB8eMTz4xpHI7A0).