### PR TITLE
update rake to avoid CVE-2020-8130

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,7 +352,7 @@ GEM
       rack (>= 1.0, < 3)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
-    rake (12.1.0)
+    rake (13.0.1)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)


### PR DESCRIPTION
See details: https://github.com/advisories/GHSA-jppv-gw3r-w3q8 