### PR TITLE
Enhance the markdown test with ()[].

### DIFF
--- a/spec/features/landing_pages_page_spec.rb
+++ b/spec/features/landing_pages_page_spec.rb
@@ -108,7 +108,7 @@ describe 'Landing Pages Pages', :type => :feature do
     return false unless string
 
     # this could be markdown, we don't test it then
-    return false if string.match(/[\*\_\~\-\#\<\>]+/)
+    return false if string.match(/[\[\]\(\)\*\_\~\-\#\<\>]+/)
 
     true
   end


### PR DESCRIPTION
Failing build:
https://github.com/sharesight/www.sharesight.com/runs/587925156?check_suite_focus=true

`[Becoming an informed investor](https://youtu.be/r2JUyqDBoRI)` should be treated as markdown and not testable..