### PR TITLE
ignore CVE-2020-8161 and CVE-2020-8165. 

### DIFF
--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Ruby Security Audit
       run: |
         bundle exec bundle-audit update
-        bundle exec bundle-audit check --ignore CVE-2014-10077
+        bundle exec bundle-audit check --ignore CVE-2014-10077 CVE-2020-8161 CVE-2020-8165
 
 
     # -------- Slack Notification when Failed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (2.3.2)
-    activesupport (4.2.9)
+    activesupport (4.2.11.3)
       i18n (~> 0.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
@@ -324,7 +324,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.4.0)
-    minitest (5.9.1)
+    minitest (5.14.1)
     multi_json (1.13.1)
     nenv (0.3.0)
     nokogiri (1.10.8)
@@ -344,7 +344,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     public_suffix (3.0.0)
-    rack (1.6.12)
+    rack (1.6.13)
     rack-livereload (0.3.16)
       rack
     rack-rewrite (1.5.1)
@@ -400,7 +400,7 @@ GEM
     thread_safe (0.3.6)
     tilt (1.4.1)
     trollop (2.1.2)
-    tzinfo (1.2.3)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uber (0.0.15)
     uglifier (2.7.2)


### PR DESCRIPTION
neither affects our middleman use here, and both require a major middleman version update