### PR TITLE
Always append locale string to landing page titles

### DIFF
--- a/extensions/landing-pages.rb
+++ b/extensions/landing-pages.rb
@@ -22,7 +22,7 @@ module Middleman
 
       # Generate all Landing Pages
       def proxy_landing_pages(locale_obj)
-        process_collection(locale_obj).each do |model|
+        landing_pages_collection(locale_obj: locale_obj, app_data: app.data).each do |model|
           app.proxy(
             path_for_proxy(model.url_slug, locale_obj[:id]),
             '/landing-pages/template.html',
@@ -30,15 +30,6 @@ module Middleman
             layout: model.layout || 'layout',
             ignore: true
           )
-        end
-      end
-
-      def process_collection(locale_obj)
-        app.data['landing-pages'].pages.map do |tuple|
-          model = tuple[1] # contentful passes ["id", { ... }]
-          localized_model = localize_entry(model, locale_obj[:lang], default_locale_obj[:lang])
-          localized_model[:title] = landing_page_title(localized_model, locale_obj: locale_obj)
-          localized_model
         end
       end
 

--- a/extensions/landing-pages.rb
+++ b/extensions/landing-pages.rb
@@ -8,6 +8,7 @@ module Middleman
   module Spaces
     class LandingPages < Middleman::Extension
       include ::ContentfulMiddleman::Helpers # grabs localize_entry
+      include MiddlemanLandingPagesHelpers
 
       def after_configuration
         if has_contentful_data? # this file will be ran before data is loaded, so we should protect it
@@ -21,10 +22,10 @@ module Middleman
 
       # Generate all Landing Pages
       def proxy_landing_pages(locale_obj)
-        process_collection(locale_obj[:lang]).each do |model|
+        process_collection(locale_obj).each do |model|
           app.proxy(
             path_for_proxy(model.url_slug, locale_obj[:id]),
-            "/landing-pages/template.html",
+            '/landing-pages/template.html',
             locals: model.merge({ locale_obj: locale_obj }).with_indifferent_access,
             layout: model.layout || 'layout',
             ignore: true
@@ -32,11 +33,13 @@ module Middleman
         end
       end
 
-      def process_collection(lang)
-        collection = app.data['landing-pages'].pages
-        collection = collection.map{ |tuple| tuple[1] } # contentful passes ["id", { ... }]
-        collection = collection.map{ |model| localize_entry(model, lang, default_locale_obj[:lang]) }
-        return collection
+      def process_collection(locale_obj)
+        app.data['landing-pages'].pages.map do |tuple|
+          model = tuple[1] # contentful passes ["id", { ... }]
+          localized_model = localize_entry(model, locale_obj[:lang], default_locale_obj[:lang])
+          localized_model[:title] = landing_page_title(localized_model, locale_obj: locale_obj)
+          localized_model
+        end
       end
 
       def has_contentful_data?

--- a/helpers/middleman/landing-pages.rb
+++ b/helpers/middleman/landing-pages.rb
@@ -17,11 +17,15 @@ module MiddlemanLandingPagesHelpers
     "#{landing_page[:page_title]} | #{locale_obj[:append_title]}"
   end
 
-  def landing_pages_collection(lang = default_locale_obj[:lang])
+  def landing_pages_collection(locale_obj: default_locale_obj, app_data: data)
+    lang = locale_obj[:lang]
+
     @landing_pages_collection ||= {}
-    @landing_pages_collection[lang] ||= data['landing-pages'].pages
-      .map{ |tuple| tuple[1] }
-      .map{ |model| localize_entry(model, lang, default_locale_obj[:lang]) }
-      .select{ |model| !model[:url_slug].blank? }
+    @landing_pages_collection[lang] ||= app_data['landing-pages'].pages.map do |tuple|
+      model = tuple[1]
+      localized_model = localize_entry(model, lang, default_locale_obj[:lang])
+      localized_model[:title] = landing_page_title(localized_model, locale_obj: locale_obj)
+      localized_model
+    end.reject{ |model| model[:url_slug].blank? }
   end
 end

--- a/helpers/middleman/landing-pages.rb
+++ b/helpers/middleman/landing-pages.rb
@@ -13,6 +13,10 @@ module MiddlemanLandingPagesHelpers
     landing_page[:url_slug]
   end
 
+  def landing_page_title(landing_page, locale_obj: default_locale_obj)
+    "#{landing_page[:page_title]} | #{locale_obj[:append_title]}"
+  end
+
   def landing_pages_collection(lang = default_locale_obj[:lang])
     @landing_pages_collection ||= {}
     @landing_pages_collection[lang] ||= data['landing-pages'].pages

--- a/source/layouts/partials/_meta.html.erb
+++ b/source/layouts/partials/_meta.html.erb
@@ -15,6 +15,7 @@
 
   # Make the locals variable seem a bit less magical.
   metas = {}
+  locals = locals.with_indifferent_access
   metas[:og_type]              = locals[:og_type] || 'website'
 
   metas[:canonical_url]        = locals[:canonical_url] || canonical_url

--- a/spec/features/landing_pages_page_spec.rb
+++ b/spec/features/landing_pages_page_spec.rb
@@ -10,7 +10,7 @@ describe 'Landing Pages Pages', :type => :feature do
 
         expect(page).to respond_successfully
         expect_campaign_code_cookie(page, landing_page)
-        expect_basic_metas(page, landing_page)
+        expect_basic_metas(page, landing_page, locale)
         expect_facebook_metas(page)
         expect_urls(page, landing_page)
         expect_elements(page, landing_page)
@@ -29,10 +29,11 @@ describe 'Landing Pages Pages', :type => :feature do
     end
   end
 
-  def expect_basic_metas(page, landing_page)
-    expect(page).to have_base_metas()
-    expect(page).to have_social_metas()
-    expect(page).to have_titles(landing_page[:page_title])
+  def expect_basic_metas(page, landing_page, locale)
+    expect(page).to have_base_metas
+    expect(page).to have_social_metas
+    expect(page.title).to match(/(#{landing_page[:page_title]})/)
+    expect(page.title).to end_with("#{locale[:append_title]}")
     expect(page).to have_descriptions(landing_page[:meta_description])
   end
 

--- a/spec/features/landing_pages_page_spec.rb
+++ b/spec/features/landing_pages_page_spec.rb
@@ -32,7 +32,7 @@ describe 'Landing Pages Pages', :type => :feature do
   def expect_basic_metas(page, landing_page, locale)
     expect(page).to have_base_metas
     expect(page).to have_social_metas
-    expect(page.title).to match(/(#{landing_page[:page_title]})/)
+    expect(page.title).to start_with(landing_page[:page_title])
     expect(page.title).to end_with("#{locale[:append_title]}")
     expect(page).to have_descriptions(landing_page[:meta_description])
   end

--- a/spec/helpers/middleman/landing_pages_spec.rb
+++ b/spec/helpers/middleman/landing_pages_spec.rb
@@ -5,25 +5,25 @@ describe 'Landing Pages Middleman Helper', :type => :helper do
     @app = Capybara.app
   end
 
-  context "landing_page_url" do
+  describe "landing_page_url" do
     # This is a proxy to other tested helpers.
     it "should return a string" do
-      get_landing_pages().each do |landing_page|
-        expect(@app.landing_page_url(landing_page)).to be_kind_of(::String)
+      get_landing_pages.each do |landing_page|
+        expect(@app.landing_page_url(landing_page)).to be_a(String)
       end
     end
   end
 
-  context "landing_page_path" do
+  describe "landing_page_path" do
     # This is a proxy to other tested helpers.
     it "should return a string" do
       get_landing_pages().each do |landing_page|
-        expect(@app.landing_page_path(landing_page)).to be_kind_of(::String)
+        expect(@app.landing_page_path(landing_page)).to be_a(String)
       end
     end
   end
 
-  context "landing_page_slug" do
+  describe "landing_page_slug" do
     it "should work as expected" do
       get_landing_pages().each do |landing_page|
         expect(@app.landing_page_slug(landing_page)).to eq(landing_page[:url_slug])
@@ -31,7 +31,31 @@ describe 'Landing Pages Middleman Helper', :type => :helper do
     end
   end
 
-  context "landing_pages_collection" do
+  describe 'landing_page_title' do
+    subject { @app.landing_page_title(landing_page) }
+
+    let(:landing_page) { get_landing_pages.sample }
+
+    it 'should append the correct locale string' do
+      expect(subject).to end_with('| Sharesight')
+    end
+
+    context 'For Australia' do
+      subject { @app.landing_page_title(landing_page, locale_obj: locale_obj) }
+
+      let(:locale_obj) { double('Locale') }
+
+      before do
+        allow(locale_obj).to receive(:[]).with(:append_title).and_return('| Sharesight Australia')
+      end
+
+      it 'should append the correct locale string' do
+        expect(subject).to end_with('| Sharesight Australia')
+      end
+    end
+  end
+
+  describe "landing_pages_collection" do
     it "should be an array of hashes" do
       data = @app.landing_pages_collection()
       expect(data).to be_kind_of(Array)


### PR DESCRIPTION
Relates to Vimaly [ticket](https://vimaly.com/#j8mqm/t/www_Landing_page_title_fields_breaking_when_differ.../S6IJ4nHLJPE3iwF92)

This PR changes landing page titles to always append the localised "| Sharesight" string. After it is deployed, the titles for landing pages will need to be manually edited or we will have double ups of e.g. "| Sharesight | Sharesight UK"