### PR TITLE
Map page description to description for landing pages

### DIFF
--- a/helpers/middleman/landing-pages.rb
+++ b/helpers/middleman/landing-pages.rb
@@ -22,9 +22,11 @@ module MiddlemanLandingPagesHelpers
 
     @landing_pages_collection ||= {}
     @landing_pages_collection[lang] ||= app_data['landing-pages'].pages.map do |tuple|
-      model = tuple[1]
+      model = tuple[1] # contentful passes ["id", { ... }]
       localized_model = localize_entry(model, lang, default_locale_obj[:lang])
       localized_model[:title] = landing_page_title(localized_model, locale_obj: locale_obj)
+      localized_model[:description] = localized_model[:page_description]
+
       localized_model
     end.reject{ |model| model[:url_slug].blank? }
   end

--- a/spec/helpers/middleman/landing_pages_spec.rb
+++ b/spec/helpers/middleman/landing_pages_spec.rb
@@ -61,6 +61,7 @@ describe 'Landing Pages Middleman Helper', :type => :helper do
       expect(data).to be_kind_of(Array)
       data.each do |a|
         expect(a).to include(:id)
+        expect(a).to include(:description)
       end
     end
   end


### PR DESCRIPTION
[vimaly](https://vimaly.com/#j8mqm/t/www_Regional_Meta_Descriptions_not_working/2tADVATUHjt1JF8qw)

Ensure landing page meta descriptions are incorporated in the page. This can be achieved by mapping locale object `page_description` to `description`, as this is what is used by the FE.