### PR TITLE
Ignore CVE-2020-8184 for now

### DIFF
--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
       - develop
-  schedule: 
+  schedule:
     - cron: '0 0 * * *'
 
 jobs:
@@ -35,7 +35,7 @@ jobs:
     - name: Ruby Security Audit
       run: |
         bundle exec bundle-audit update
-        bundle exec bundle-audit check --ignore CVE-2014-10077 CVE-2020-8161 CVE-2020-8165
+        bundle exec bundle-audit check --ignore CVE-2014-10077 CVE-2020-8161 CVE-2020-8165 CVE-2020-8184
 
 
     # -------- Slack Notification when Failed


### PR DESCRIPTION
Requires a major middleman version update.