### PR TITLE
Ignore kramdown vulnerability for now

### DIFF
--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -35,7 +35,8 @@ jobs:
     - name: Ruby Security Audit
       run: |
         bundle exec bundle-audit update
-        bundle exec bundle-audit check --ignore CVE-2014-10077 CVE-2020-8161 CVE-2020-8165 CVE-2020-8184
+        bundle exec bundle-audit check --ignore CVE-2014-10077 CVE-2020-8161 CVE-2020-8165 CVE-2020-8184 CVE-2020-14001
+
 
 
     # -------- Slack Notification when Failed


### PR DESCRIPTION
Requires a major middleman version update. If we used build servers
would need to update.

[vulnerability](https://github.com/advisories/GHSA-mqm2-cgpr-p4m6)