### PR TITLE
Refactor the Footer Links to Flex.

### DIFF
--- a/source/css/components/_footer.scss
+++ b/source/css/components/_footer.scss
@@ -15,25 +15,136 @@ footer#footer {
   }
 }
 
+%footer-flex {
+  flex: 1 1 100%;
+  padding: 0 $gutter/2;
+
+  margin: 0;
+  margin-bottom: $gutter;
+  @include respond-to(md, min) {
+    margin-bottom: $gutter*1.5;
+  }
+}
+
 .footer {
   &__container {
     @extend %contain-row;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
 
     @include respond-to(lg, min) {
       padding: 0 10%;
     }
   }
 
+  /* Flexing Columns/Containers */
+  &__head, &__actions, &__links_container, &__links, &__regional-links {
+    @extend %footer-flex;
+  }
+
   &__head {
-    @extend %column--12;
     text-align: center;
-    margin-bottom: $gutter;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: flex-end;
+    flex-direction: column;
+    flex-wrap: wrap;
+
+    @include respond-to(sm, min) {
+      flex-basis: percentage(1/2);
+    }
 
     @include respond-to(md, min) {
-      margin-bottom: $gutter*2;
+      flex-basis: percentage(1/3);
+    }
+
+    @include respond-to(lg, min) {
+      flex-basis: percentage(1/4);
+    }
+
+    > * + * {
+      margin-top: $gutter/2;
     }
   }
 
+  &__links_container {
+    display: flex;
+    align-items: flex-start;
+    flex-direction: row;
+    flex-wrap: wrap;
+
+    // This should be the remainder of `footer__actions`.
+    @include respond-to(sm, min) {
+      flex-basis: percentage(1/2);
+    }
+
+    @include respond-to(md, min) {
+      flex-basis: percentage(2/3);
+    }
+
+    @include respond-to(lg, min) {
+      flex-basis: percentage(3/4);
+    }
+  }
+
+  &__links {
+    list-style: none;
+    outline: none;
+
+    flex: 1 1 50%;
+    &--double-width {
+      flex-basis: 100%;
+    }
+
+    @include respond-to(md, min) {
+      flex-basis: 25%;
+      &--double-width {
+        flex-basis: 40%; // NOTE: Not actually "double" here, just larger.
+      }
+    }
+
+    &--double-width {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      justify-content: flex-start;
+      align-items: start;
+
+      li {
+        flex-basis: 100%;
+
+        // Headers should only be 50% width, left-aligned.
+        &[role="none"] {
+          flex-basis: 50%;
+          margin-right: 50%;
+        }
+
+        // Menu Items are 50% width and should be laid out in a grid below.
+        &[role="menuitem"] {
+          flex-basis: 50%;
+        }
+      }
+    }
+  }
+
+  &__regional-links {
+    text-align: center;
+    list-style: none;
+    outline: none;
+
+    li {
+      display: inline-block;
+    }
+
+    li + li {
+      margin-left: $gutter;
+    }
+  }
+
+  /* Nested Components */
   &__logo {
     width: 75%;
     max-width: 160px;
@@ -47,27 +158,6 @@ footer#footer {
     font-size: 1.25rem;
     line-height: 1.5;
     margin: 0;
-  }
-
-  &__actions {
-    @extend %column--12;
-    @extend %column__sm--6;
-    @extend %column__md--4;
-    @extend %column__lg--3;
-    @extend %column__lg--offset-right-1;
-    display: flex;
-    align-items: flex-end;
-    flex-direction: column;
-    flex-wrap: wrap;
-    margin-bottom: $gutter;
-
-    @include respond-to(md, min) {
-      margin-bottom: $gutter*1.5;
-    }
-
-    > * + * {
-      margin-top: $gutter/2;
-    }
   }
 
   &__buttons, &__apps {
@@ -187,43 +277,6 @@ footer#footer {
         text-shadow: 0 0 0 #fff; // NOTE: same as color above!
         border: 0;
       }
-    }
-  }
-
-  &__links {
-    @extend %column--6;
-    @extend %column__sm--3;
-    @extend %column__md--2;
-    margin-top: 0;
-    margin-bottom: $gutter;
-
-    @include respond-to(md, min) {
-      margin-bottom: $gutter*1.5;
-    }
-
-    list-style: none;
-    outline: none;
-  }
-
-  &__regional-links {
-    @extend %column--12;
-    text-align: center;
-    margin-top: 0;
-    margin-bottom: $gutter;
-
-    @include respond-to(md, min) {
-      margin-bottom: $gutter*1.5;
-    }
-
-    list-style: none;
-    outline: none;
-
-    li {
-      display: inline-block;
-    }
-
-    li + li {
-      margin-left: $gutter;
     }
   }
 

--- a/source/partials/_site_footer.html.erb
+++ b/source/partials/_site_footer.html.erb
@@ -55,110 +55,112 @@
       </div>
     </div>
 
-    <ul class="footer__links" id="main-menu" role="menubar" aria-label="Company Links">
-      <li role="none" class="footer__link-header">Company</li>
-      <li role="menuitem">
-        <a href="<%= localize_url(locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'index')[:page_title] %>">
-          Home
-        </a>
-      </li>
+    <div class="footer__links_container">
+      <ul class="footer__links footer__links--double-width" id="main-menu" role="menubar" aria-label="Company Links">
+        <li role="none" class="footer__link-header">Company</li>
+        <li role="menuitem">
+          <a href="<%= localize_url(locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'index')[:page_title] %>">
+            Home
+          </a>
+        </li>
 
-      <li role="menuitem">
-        <a href="<%= localize_url('team', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'team')[:page_title] %>">
-          Executive Team
-        </a>
-      </li>
+        <li role="menuitem">
+          <a href="<%= localize_url('team', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'team')[:page_title] %>">
+            Executive Team
+          </a>
+        </li>
 
-      <li role="menuitem">
-        <a href="<%= localize_url('about-sharesight', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'about-sharesight')[:page_title] %>">
-          About Us
-        </a>
-      </li>
+        <li role="menuitem">
+          <a href="<%= localize_url('about-sharesight', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'about-sharesight')[:page_title] %>">
+            About Us
+          </a>
+        </li>
 
-      <li role="menuitem">
-        <a href="<%= localize_url('pricing', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'pricing')[:page_title] %>">
-          Pricing
-        </a>
-      </li>
+        <li role="menuitem">
+          <a href="<%= localize_url('pricing', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'pricing')[:page_title] %>">
+            Pricing
+          </a>
+        </li>
 
-      <li role="menuitem">
-        <a href="<%= localize_url('reviews', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'reviews')[:page_title] %>">
-          Reviews
-        </a>
-      </li>
+        <li role="menuitem">
+          <a href="<%= localize_url('reviews', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'reviews')[:page_title] %>">
+            Reviews
+          </a>
+        </li>
 
-      <li role="menuitem">
-        <a href="<%= localize_url('faq', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'faq')[:page_title] %>">
-          FAQ
-        </a>
-      </li>
+        <li role="menuitem">
+          <a href="<%= localize_url('faq', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'faq')[:page_title] %>">
+            FAQ
+          </a>
+        </li>
 
-      <li role="menuitem">
-        <a href="<%= unlocalized_url('blog') %>" class="footer__link" title="Sharesight Blog">
-          Blog
-        </a>
-      </li>
+        <li role="menuitem">
+          <a href="<%= unlocalized_url('blog') %>" class="footer__link" title="Sharesight Blog">
+            Blog
+          </a>
+        </li>
 
-      <li role="menuitem">
-        <a href="<%= localize_url('events', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'events')[:page_title] %>">
-          Webinars & Events
-        </a>
-      </li>
+        <li role="menuitem">
+          <a href="<%= localize_url('events', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'events')[:page_title] %>">
+            Webinars & Events
+          </a>
+        </li>
 
-      <li role="menuitem">
-        <a href="<%= localize_url('partners', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'partners')[:page_title] %>">
-          Partners
-        </a>
-      </li>
-    </ul>
+        <li role="menuitem">
+          <a href="<%= localize_url('partners', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'partners')[:page_title] %>">
+            Partners
+          </a>
+        </li>
+      </ul>
 
-    <ul class="footer__links" role="menubar" aria-label="Resources Links">
-      <li role="none" class="footer__link-header">Resources</li>
-      <li role="menuitem">
-        <a href="<%= config[:api_url] %>" class="footer__link" title="Sharesight Developer API">
-          Developer API
-        </a>
-      </li>
+      <ul class="footer__links" role="menubar" aria-label="Resources Links">
+        <li role="none" class="footer__link-header">Resources</li>
+        <li role="menuitem">
+          <a href="<%= config[:api_url] %>" class="footer__link" title="Sharesight Developer API">
+            Developer API
+          </a>
+        </li>
 
-      <li role="menuitem">
-        <a href="<%= localize_url('privacy-policy', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'privacy-policy')[:page_title] %>">
-          Privacy Policy
-        </a>
-      </li>
+        <li role="menuitem">
+          <a href="<%= localize_url('privacy-policy', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'privacy-policy')[:page_title] %>">
+            Privacy Policy
+          </a>
+        </li>
 
-      <li role="menuitem">
-        <a href="<%= localize_url('sharesight-terms-of-use', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'sharesight-terms-of-use')[:page_title] %>">
-          Terms of Use
-        </a>
-      </li>
+        <li role="menuitem">
+          <a href="<%= localize_url('sharesight-terms-of-use', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'sharesight-terms-of-use')[:page_title] %>">
+            Terms of Use
+          </a>
+        </li>
 
-      <li role="menuitem">
-        <a href="<%= localize_url('sharesight-professional-terms-of-use', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'sharesight-professional-terms-of-use')[:page_title] %>">
-          Pro Terms of Use
-        </a>
-      </li>
-    </ul>
+        <li role="menuitem">
+          <a href="<%= localize_url('sharesight-professional-terms-of-use', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'sharesight-professional-terms-of-use')[:page_title] %>">
+            Pro Terms of Use
+          </a>
+        </li>
+      </ul>
 
-    <ul class="footer__links" role="menubar" aria-label="Support Links">
-      <li role="none" class="footer__link-header">Support</li>
-      <li role="menuitem">
-        <a href="<%= localize_url(base_url: config[:help_url], locale_id: locale_obj[:id]) %>" class="footer__link" title="Help | <%= locale_obj[:append_title] %>">
-          Help
-        </a>
-      </li>
+      <ul class="footer__links" role="menubar" aria-label="Support Links">
+        <li role="none" class="footer__link-header">Support</li>
+        <li role="menuitem">
+          <a href="<%= localize_url(base_url: config[:help_url], locale_id: locale_obj[:id]) %>" class="footer__link" title="Help | <%= locale_obj[:append_title] %>">
+            Help
+          </a>
+        </li>
 
-      <li role="menuitem">
-        <a href="<%= config[:community_url] %>" class="footer__link" title="Sharesight Community Forum">
-          Community Forum
-        </a>
-      </li>
+        <li role="menuitem">
+          <a href="<%= config[:community_url] %>" class="footer__link" title="Sharesight Community Forum">
+            Community Forum
+          </a>
+        </li>
 
-      <li role="menuitem">
-        <a href="mailto:sales@sharesight.com" class="footer__link" title="Email the Sales Team">
-          sales@sharesight.com
-        </a>
-      </li>
-    </ul>
+        <li role="menuitem">
+          <a href="mailto:sales@sharesight.com" class="footer__link" title="Email the Sales Team">
+            sales@sharesight.com
+          </a>
+        </li>
+      </ul>
+    </div>
 
     <ul class="footer__regional-links" role="menubar" aria-label="Regional Website Links">
       <li role="none" class="footer__link-header">Region</li>

--- a/source/partials/_site_footer.html.erb
+++ b/source/partials/_site_footer.html.erb
@@ -65,32 +65,14 @@
         </li>
 
         <li role="menuitem">
-          <a href="<%= localize_url('team', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'team')[:page_title] %>">
-            Executive Team
-          </a>
-        </li>
-
-        <li role="menuitem">
-          <a href="<%= localize_url('about-sharesight', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'about-sharesight')[:page_title] %>">
-            About Us
-          </a>
-        </li>
-
-        <li role="menuitem">
-          <a href="<%= localize_url('pricing', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'pricing')[:page_title] %>">
-            Pricing
-          </a>
-        </li>
-
-        <li role="menuitem">
-          <a href="<%= localize_url('reviews', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'reviews')[:page_title] %>">
-            Reviews
-          </a>
-        </li>
-
-        <li role="menuitem">
           <a href="<%= localize_url('faq', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'faq')[:page_title] %>">
             FAQ
+          </a>
+        </li>
+
+        <li role="menuitem">
+          <a href="<%= localize_url('team', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'team')[:page_title] %>">
+            Executive Team
           </a>
         </li>
 
@@ -101,14 +83,32 @@
         </li>
 
         <li role="menuitem">
+          <a href="<%= localize_url('about-sharesight', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'about-sharesight')[:page_title] %>">
+            About Us
+          </a>
+        </li>
+
+        <li role="menuitem">
           <a href="<%= localize_url('events', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'events')[:page_title] %>">
             Webinars & Events
           </a>
         </li>
 
         <li role="menuitem">
+          <a href="<%= localize_url('pricing', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'pricing')[:page_title] %>">
+            Pricing
+          </a>
+        </li>
+
+        <li role="menuitem">
           <a href="<%= localize_url('partners', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'partners')[:page_title] %>">
             Partners
+          </a>
+        </li>
+
+        <li role="menuitem">
+          <a href="<%= localize_url('reviews', locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_page(page: 'reviews')[:page_title] %>">
+            Reviews
           </a>
         </li>
       </ul>


### PR DESCRIPTION
A PR into #202 for [story](https://vimaly.com/#j8mqm/t/www_helpsite_Add_Reviews_link_to_footer/Xc1vCD2gUb4AYNzCY).

This just adds proper `display: flex`.

Different sizes:
<img width="383" alt="Screen Shot 2020-09-09 at 3 39 29 PM" src="https://user-images.githubusercontent.com/4203271/92552357-8fdecd80-f2b4-11ea-8c45-7a34a4a90319.png">
<img width="565" alt="Screen Shot 2020-09-09 at 3 39 21 PM" src="https://user-images.githubusercontent.com/4203271/92552359-910ffa80-f2b4-11ea-8bd8-e2e0b0a9275b.png">
<img width="645" alt="Screen Shot 2020-09-09 at 3 39 15 PM" src="https://user-images.githubusercontent.com/4203271/92552361-91a89100-f2b4-11ea-817c-22a44acc964f.png">
<img width="475" alt="Screen Shot 2020-09-09 at 3 39 03 PM" src="https://user-images.githubusercontent.com/4203271/92552365-92412780-f2b4-11ea-8864-51d44150f3a0.png">
<img width="161" alt="Screen Shot 2020-09-09 at 3 39 45 PM" src="https://user-images.githubusercontent.com/4203271/92552352-8ce3dd00-f2b4-11ea-906e-2d3d106099ad.png">
