### PR TITLE
Updating home page sub-header to match the more-user centric heading text

### DIFF
--- a/data/locales.json
+++ b/data/locales.json
@@ -21,7 +21,7 @@
         "page": "index",
         "page_title": "Stock Portfolio Tracker | Sharesight",
         "page_description": "Leading online stock portfolio tracker & reporting tool for investors. Sharesight tracks stock prices, trades, dividends, performance and tax!",
-        "tagline": "Simply the best stock portfolio tracker for investors.",
+        "tagline": "With the best stock portfolio tracker for investors.",
         "footer_tagline": "Simply the best portfolio management tool for DIY investors.",
         "sitemap_priority": 1,
         "sitemap_changefreq": "daily"
@@ -157,7 +157,7 @@
         "page": "index",
         "page_title": "Share Portfolio Tracker | Sharesight Australia",
         "page_description": "Leading online share portfolio tracker & reporting tool for Australian investors. Sharesight tracks share prices, trades, dividends, performance & tax!",
-        "tagline": "Simply the best share portfolio tracker for Australian investors.",
+        "tagline": "With the best share portfolio tracker for Australian investors.",
         "footer_tagline": "Simply the best portfolio management tool for Australian DIY investors.",
         "sitemap_priority": 1,
         "sitemap_changefreq": "daily"
@@ -270,7 +270,7 @@
         "page": "index",
         "page_title": "Stock Portfolio Tracker | Sharesight Canada",
         "page_description": "Leading online stock portfolio tracker & reporting tool for Canadian investors. Sharesight tracks stock prices, trades, dividends, performance and tax!",
-        "tagline": "Simply the best stock portfolio tracker for Canadian investors.",
+        "tagline": "With the best stock portfolio tracker for Canadian investors.",
         "footer_tagline": "Simply the best portfolio management tool for Canadian DIY investors.",
         "sitemap_priority": 1,
         "sitemap_changefreq": "daily"
@@ -383,7 +383,7 @@
         "page": "index",
         "page_title": "Share Portfolio Tracker | Sharesight New Zealand",
         "page_description": "Leading online share portfolio tracker & reporting tool for New Zealand investors. Sharesight tracks share prices, trades, dividends, performance & tax!",
-        "tagline": "Simply the best share portfolio tracker for New Zealand investors.",
+        "tagline": "With the best share portfolio tracker for New Zealand investors.",
         "footer_tagline": "Simply the best portfolio management tool for New Zealand DIY investors.",
         "sitemap_priority": 1,
         "sitemap_changefreq": "daily"
@@ -497,7 +497,7 @@
         "page": "index",
         "page_title": "Share Portfolio Tracker | Sharesight UK",
         "page_description": "Leading online share portfolio tracker & reporting tool for UK investors. Sharesight tracks share prices, trades, dividends, performance & tax!",
-        "tagline": "Simply the best share portfolio tracker for UK investors.",
+        "tagline": "With the best share portfolio tracker for UK investors.",
         "footer_tagline": "Simply the best portfolio management tool for UK DIY investors.",
         "sitemap_priority": 1,
         "sitemap_changefreq": "daily"

--- a/source/partials/_site_header_index.html.erb
+++ b/source/partials/_site_header_index.html.erb
@@ -19,7 +19,7 @@
   />
 
   <div class="index-hero__text">
-    <h1 class="index-hero__title">Become a better investor</h1>
+    <h1 class="index-hero__title">Become a Better Investor</h1>
 
     <h2 class="index-hero__intro">
       <%= locale_page(page: 'index', locale_obj: locale_obj)[:tagline] %>

--- a/source/partials/_site_header_index.html.erb
+++ b/source/partials/_site_header_index.html.erb
@@ -19,7 +19,7 @@
   />
 
   <div class="index-hero__text">
-    <h1 class="index-hero__title">Meet Sharesight</h1>
+    <h1 class="index-hero__title">Become a better investor</h1>
 
     <h2 class="index-hero__intro">
       <%= locale_page(page: 'index', locale_obj: locale_obj)[:tagline] %>

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Index Page', :type => :feature do
   it "should have a hero title" do
     visit '/'
-    expect(page).to have_css('h1', text: 'Meet Sharesight')
+    expect(page).to have_css('h1', text: 'Become a better investor')
   end
 
   it "should have a get started button in the hero" do

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Index Page', :type => :feature do
   it "should have a hero title" do
     visit '/'
-    expect(page).to have_css('h1', text: 'Become a better investor')
+    expect(page).to have_css('h1', text: 'Become a Better Investor')
   end
 
   it "should have a get started button in the hero" do

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -14,7 +14,7 @@ describe 'Index Page', :type => :feature do
   Capybara.app.data.locales.each do |locale|
     it "should have localized text for locale #{locale['id']}" do
       visit locale.path
-      expect(page).to have_text("Simply the best #{locale.cert_type} portfolio tracker for #{locale.for_country} investors".squeeze(' '))
+      expect(page).to have_text("With the best #{locale.cert_type} portfolio tracker for #{locale.for_country} investors.".squeeze(' '))
     end
   end
 end


### PR DESCRIPTION
An extension of [this PR](https://github.com/sharesight/www.sharesight.com/pull/216)

The story can be found on [Vimaly](https://vimaly.com/#j8mqm/t/www_Change_text_on_the_marketing_homepage/bMJIoOEk40apMpb5x)

Basically updated the locales.json files, replacing 'Simply' with 'With' 