### PR TITLE
Install and use `bundler@1.x` in CI.

### DIFF
--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Install Ruby Dependencies
       run: |
-        gem install bundler
+        gem install bundler -v "<2"
         bundle install --jobs 4 --retry 3
 
     - name: Ruby Security Audit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
         ruby-version: '2.4.x'
     - name: Install Ruby Dependencies
       run: |
-        gem install bundler
+        gem install bundler -v "<2"
         bundle install --jobs 4 --retry 3
 
 


### PR DESCRIPTION
Looks like Bundler v2 or strictly v2.2 might not work?  Unclear how this broke on its own, but we have a `gem install bundler` without a version target.

CI Failure:
https://github.com/sharesight/www.sharesight.com/pull/219/checks?check_run_id=1533993427

Partial Log:
```
Run gem install bundler
Successfully installed bundler-2.2.0
Parsing documentation for bundler-2.2.0
Installing ri documentation for bundler-2.2.0
Done installing documentation for bundler after 5 seconds
1 gem installed
Fetching https://github.com/vast/middleman-es6
Fetching gem metadata from https://rubygems.org/.........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies............
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler-audit x86_64-linux was resolved to 0.6.0, which depends on
      bundler (~> 1.2)

    middleman (~> 3.4.1) x86_64-linux was resolved to 3.4.1, which depends on
middleman-core (= 3.4.1) x86_64-linux was resolved to 3.4.1, which depends
on
        bundler (~> 1.1)

  Current Bundler version:
    bundler (2.2.0)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?
```