### PR TITLE
Switch Testimonials from ProductReviews to TrustPilot.

### DIFF
--- a/source/css/sections/_product_review.scss
+++ b/source/css/sections/_product_review.scss
@@ -1,3 +1,0 @@
-.section--product-review {
-  text-align: center;
-}

--- a/source/page-index.html.erb
+++ b/source/page-index.html.erb
@@ -12,17 +12,7 @@ layout: layout_index
 <%= partial "sections/pricing", locals: { locale_obj: locale_obj } %>
 <%= partial "sections/partners", locals: { locale_obj: locale_obj } %>
 
-<% if locale_obj[:id] === "au" || locale_obj[:id] === "nz" %>
-  <%# product_review is specific to AU/NZ %>
-  <%= partial "sections/product_review", locals: { locale_obj: locale_obj } %>
-<% else %>
-  <%= partial "sections/testimonials", locals: {
-    json: data.testimonials,
-    testimonial_heading: data.seo_home.find{|x| x[:id] == locale_obj[:id] }[:testimonial_heading],
-    customer_type: 'Sharesight',
-    locale_obj: locale_obj
-  } %>
-<% end %>
+<%= partial "sections/trustpilot", locals: { locale_obj: locale_obj } %>
 
 <div class="section section--text section_video">
   <div class="container">

--- a/source/sections/_product_review.html.erb
+++ b/source/sections/_product_review.html.erb
@@ -1,7 +1,0 @@
-<section class="section section--product-review alternate">
-  <div class="container">
-    <!-- snippet from productreview.com.au -->
-    <div class="productreviewwidget" data-listing-id="687bc3b6-3c1b-3de5-84d8-440d0c0e3d6f" data-full-width="1" data-num-reviews="3" data-order="best" data-layout="horizontal" data-theme-id="light" data-version="1"></div>
-    <script type="text/javascript"> (function() { function async_load(){ var s = document.createElement("script"); s.type = "text/javascript"; s.async = true; s.src = '//www.productreview.com.au/assets/js/widget/reviews-itemid.js'; var x = document.getElementsByTagName("script")[0]; x.parentNode.insertBefore(s, x); } if (window.attachEvent) { window.attachEvent("onload", async_load); } else { window.addEventListener("load", async_load, false); } })(); </script>
-  </div>
-</section>

--- a/source/sections/_trustpilot.html.erb
+++ b/source/sections/_trustpilot.html.erb
@@ -26,7 +26,7 @@
       data-stars="4,5"
       data-review-languages="en"
     >
-      <a href="https://au.trustpilot.com/review/www.sharesight.com" target="_blank" rel="noopener noreferrer">
+      <a href="https://<%= trustpilot_subdomain %>.trustpilot.com/review/www.sharesight.com" target="_blank" rel="noopener noreferrer">
         See what our customers are saying on Trustpilot
       </a>
     </div>

--- a/source/sections/_trustpilot.html.erb
+++ b/source/sections/_trustpilot.html.erb
@@ -1,0 +1,36 @@
+<%
+  locale_obj = locals[:locale_obj] || current_locale_obj
+  tag_id = locale_obj[:id] # This should be au, nz, ca, uk, global, etc…
+
+  # NOTE: For global, this should be "en-US"
+  trustpilot_lang = locale_obj[:lang] # This should be en-AU, en-NZ, en-CA, en-GB, en-US, etc…
+  trustpilot_lang = "en-US" if tag_id == "global"
+
+  # NOTE: For global, this should be "www"
+  trustpilot_subdomain = tag_id # This should be au, nz, ca, uk, etc…
+  trustpilot_subdomain = "www" if tag_id == "global"
+%>
+
+<section class="section alternate">
+  <div class="container">
+    <!-- snippet from Trustpilot -->
+    <div
+      class="trustpilot-widget"
+      data-locale="<%= trustpilot_lang %>"
+      data-template-id="539adbd6dec7e10e686debee"
+      data-businessunit-id="5e4b8f349f19c6000198ff88"
+      data-style-height="450px"
+      data-style-width="100%"
+      data-theme="light"
+      data-tags="widget-general-<%= tag_id %>"
+      data-stars="4,5"
+      data-review-languages="en"
+    >
+      <a href="https://au.trustpilot.com/review/www.sharesight.com" target="_blank" rel="noopener noreferrer">
+        See what our customers are saying on Trustpilot
+      </a>
+    </div>
+
+    <script type="text/javascript" src="//widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js" async></script>
+  </div>
+</section>


### PR DESCRIPTION
[Vimaly Story](https://vimaly.com/#j8mqm/t/www_Trustpilot_widget_on_home_page/mlEYg3PbWo9J8sHNp)

 - ProductReviews had an outage, so I prompted a change and we want TrustPilot everywhere, even replacing the old Testimonials.
 - These are fully localized better by the looks..

**Still could do:** 
 - Remove Testimonials altogether (still used on Pro, Xero, and maybe Contentful).  Pinged Angela.