### PR TITLE
Add tax-deductable blurb to NZ locale

### DIFF
--- a/source/page-pricing.html.erb
+++ b/source/page-pricing.html.erb
@@ -81,7 +81,7 @@ section_class: 'section_default'
       Prices in <%= locale_obj[:currency] %>
       <% if locale_obj[:plans_include_tax] %>including GST<% else %>and tax-free<% end %>.
 
-      <% if locale_obj[:id] == 'au' %>
+      <% if %w(nz au).include?(locale_obj[:id]) %>
         Sharesight might be tax-deductible, ask your accountant for details.
       <% end %>
       &nbsp;All paid plans include a 7 day free trial.


### PR DESCRIPTION
As per title on pricing page. [ticket](https://vimaly.com/#j8mqm/t/www_Add_tax_deduction_blurb_to_NZ_pricing_page/V28pKMuVNQBiQEokl)