### PR TITLE
Redesign Navigation: Dynamic, shared data source.

### DIFF
--- a/source/css/components/_navigation.scss
+++ b/source/css/components/_navigation.scss
@@ -308,12 +308,12 @@ $__link_indentation: 28px; // indentation to have links and icons be a bit consi
   }
 
   // Requires a `<div class="menu__row" />` around it.
-  &__half {
+  &__split-2 {
     flex: 1 1 50%;
   }
 
   // Requires a `<div class="menu__row" />` around it.
-  &__column {
+  &__split-3 {
     flex: 1 1 percentage(1/3);
   }
 }

--- a/source/partials/header/_blog.html.erb
+++ b/source/partials/header/_blog.html.erb
@@ -1,0 +1,15 @@
+<div class="menu__background menu__blog">
+  <a class="menu__label menu__title" role="separator" href="/blog">
+    <i class="ph-pencil-circle menu__icon" role="img" aria-label="From the Blog"></i>
+    <span class="menu__label-text">From the Blog</span>
+  </a>
+
+  <% data.blog.posts.values.first(3).each do |blog_post| %>
+    <%= partial "partials/header/link", locals: {
+      title: blog_post[:title],
+      href: post_url(blog_post),
+      truncate: 75,
+      compact: true
+    } %>
+  <% end %>
+</div>

--- a/source/partials/header/_desktop_navigation.html.erb
+++ b/source/partials/header/_desktop_navigation.html.erb
@@ -1,259 +1,39 @@
-<%# NOTE: Only the FIRST Navigation should have a tabindex="0" all else should be "-1" %>
+<%
+  menus = locals[:menus]
+%>
+
 <ul class="nav__menubar" role="menubar" aria-label="Sharesight Navigation Menu">
-  <li class="nav__menubar-item" role="none">
-    <button class="nav__menubar-button" aria-controls="menu-features" aria-haspopup="true" aria-expanded="false" id="nav-features" tabindex="0">
-      Features
+  <% menus.each_with_index do |menu, index| %>
+    <%
+      button_element = menu[:href] ? 'a' : 'button'
+      has_nested_links = menu[:rows]&.length
+    %>
 
-      <%= partial "partials/header/caret" %>
-    </button>
+    <li class="nav__menubar-item" role="none">
+      <<%= button_element %>
+        class="nav__menubar-button"
+        id="nav-<%= menu[:label] %>"
+        <%= "aria-controls=\"menu-#{menu[:label]}\"" if has_nested_links %>
+        <%= "aria-haspopup=\"true\"" if has_nested_links %>
+        <%= "aria-expanded=\"false\"" if has_nested_links %>
+        <%= "title=\"#{menu[:title]}\"" if menu[:title] %>
+        <%= "href=\"#{menu[:href]}\"" if menu[:href] %>
+        tabindex="<%= index === 0 ? 0 : -1 %>" <%# NOTE: Only the FIRST Navigation should have a tabindex="0" all else should be "-1" %>
+      >
+        <%= menu[:label] %>
 
-    <div class="nav__menu menu" role="menu" aria-labelledby="nav-features" id="menu-features">
-      <div class="menu__row">
-        <div class="menu__half">
-          <div class="menu__title" role="separator">Features</div>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'trend-up',
-            icon_hover: 'chart-line-up-bold',
-            title: 'Performance',
-            href: '/TODO',
-          } %>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'coin',
-            title: 'Dividends',
-            href: '/TODO',
-          } %>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'receipt',
-            icon_hover: 'article-fill',
-            title: 'Tax Reporting',
-            href: '/TODO',
-          } %>
-        </div>
-
-        <div class="menu__half">
-          <div class="menu__title" role="separator">What we Track</div>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'squares-four',
-            icon_hover: 'grid-four-fill',
-            title: 'Supported Investments',
-            href: '/TODO',
-          } %>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'globe-hemisphere-west',
-            icon_hover: 'globe-hemisphere-east-fill',
-            title: 'Supported Exchanges',
-            href: '/TODO',
-          } %>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'bank',
-            title: 'Supported Brokers',
-            href: '/TODO',
-          } %>
-        </div>
-      </div>
-
-      <div class="menu__row menu__background">
-        <div class="menu__half">
-          <%= partial "partials/header/link", locals: {
-            icon: 'question',
-            title: 'Frequently Asked Questions',
-            href: '/faq',
-          } %>
-        </div>
-
-        <div class="menu__half">
-          <%= partial "partials/header/link", locals: {
-            icon: 'shield',
-            icon_hover: 'shield-check-fill',
-            title: 'Data Security',
-            href: '/TODO',
-          } %>
-        </div>
-      </div>
-    </div>
-  </li>
-
-  <li class="nav__menubar-item" role="none">
-    <button class="nav__menubar-button" aria-controls="menu-benefits" aria-haspopup="true" aria-expanded="false" id="nav-benefits" tabindex="0">
-      Benefits
-
-      <%= partial "partials/header/caret" %>
-    </button>
-
-    <div class="nav__menu menu" role="menu" aria-labelledby="nav-benefits" id="menu-benefits">
-      <%= partial "partials/header/link", locals: {
-        icon: 'user',
-        title: 'Investors',
-        href: '/TODO',
-        description: 'Over 150,000 Investors around the world track their portfolios with Sharesight.'
-      } %>
-
-      <%= partial "partials/header/link", locals: {
-        compact: true,
-        title: 'Read the Reviews',
-        href: '/reviews',
-      } %>
-
-      <%= partial "partials/header/link", locals: {
-        icon: 'users',
-        title: 'Finance Professionals',
-        href: '/TODO',
-        description: 'Use Sharesight Pro to grow your business.'
-      } %>
-
-      <%= partial "partials/header/link", locals: {
-        icon: 'buildings',
-        title: 'Finance Companies',
-        href: '/TODO',
-        description: 'Partner with Sharesight and grow your business.'
-      } %>
-
-    </div>
-  </li>
-
-  <li class="nav__menubar-item" role="none">
-    <a class="nav__menubar-button" href="<%= localize_url('pricing', locale_id: locale_obj[:id]) %>" title="<%= locale_page(page: 'pricing', locale_obj: locale_obj)[:page_title] %>" tabindex="0">
-      Pricing
-    </a>
-  </li>
-
-  <li class="nav__menubar-item" role="none">
-    <button class="nav__menubar-button" aria-controls="menu-resources" aria-haspopup="true" aria-expanded="false" id="nav-resources" tabindex="0">
-      Resources
-
-      <%= partial "partials/header/caret" %>
-    </button>
-
-    <div class="nav__menu menu menu--lg" role="menu" aria-labelledby="nav-resources" id="menu-resources">
-      <div class="menu__row">
-        <div class="menu__column">
-          <div class="menu__title" role="separator">Company</div>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'magnifying-glass',
-            title: 'About Sharesight',
-            href: '/TODO',
-          } %>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'user-rectangle',
-            title: 'Executive Team',
-            href: '/TODO',
-          } %>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'briefcase',
-            title: 'Careers',
-            href: '/TODO',
-          } %>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'megaphone-simple',
-            title: 'Media Center',
-            href: '/TODO',
-          } %>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'smiley',
-            icon_hover: 'smiley-wink-fill',
-            title: 'Reviews',
-            href: '/TODO',
-          } %>
-        </div>
-
-        <div class="menu__column">
-          <div class="menu__title" role="separator">Work with Us</div>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'identification-card',
-            title: 'Partner Directory',
-            href: '/TODO',
-          } %>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'handshake',
-            title: 'Become a Partner',
-            href: '/TODO',
-          } %>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'share-network',
-            icon_hover: 'fire-fill',
-            title: 'Become an Affiliate',
-            href: '/TODO',
-          } %>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'envelope-simple',
-            icon_hover: 'envelope-simple-open',
-            title: 'sales@sharesight.com',
-            href: 'mailto:sales@sharesight.com',
-          } %>
-        </div>
-
-        <div class="menu__column">
-          <div class="menu__title" role="separator">Resources</div>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'info',
-            title: 'Help Centre',
-            href: '/TODO',
-          } %>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'code',
-            title: 'Sharesight API',
-            href: '/TODO',
-          } %>
-
-          <%= partial "partials/header/link", locals: {
-            compact: true,
-            icon: 'monitor-play',
-            icon_hover: 'monitor-fill',
-            title: 'Events & Webinars',
-            href: '/TODO',
-          } %>
-        </div>
-      </div>
-
-      <div class="menu__background menu__blog">
-        <a class="menu__label menu__title" role="separator" href="/blog">
-          <i class="ph-pencil-circle menu__icon" role="img" aria-label="From the Blog"></i>
-          <span class="menu__label-text">From the Blog</span>
-        </a>
-
-        <% data.blog.posts.values.first(3).each do |blog_post| %>
-          <%= partial "partials/header/link", locals: {
-            title: blog_post[:title],
-            href: post_url(blog_post),
-            truncate: 75,
-            compact: true
-          } %>
+        <% if has_nested_links %>
+          <%= partial "partials/header/caret" %>
         <% end %>
-      </div>
-    </div>
-  </li>
+      </<%= button_element %>>
+
+      <% if has_nested_links %>
+        <div class="nav__menu menu <%= menu[:class] %>" role="menu" aria-labelledby="nav-<%= menu[:label] %>" id="menu-<%= menu[:label] %>">
+          <% menu[:rows].each do |row| %>
+            <%= partial row[:partial] || 'partials/header/row', locals: { row: row } %>
+          <% end %> <%# ends menu[:rows].each %>
+        </div> <%# closes "nav__menu menu" %>
+      <% end %>
+    </li>
+  <% end %> <%# ends menus.each_with_index %>
 </ul>

--- a/source/partials/header/_navigation.html.erb
+++ b/source/partials/header/_navigation.html.erb
@@ -9,12 +9,240 @@
     - We do not do keyboard search like "c" to go to "Company", etc. (I can't find a real-world example of thise anyways)
 %>
 
+<%
+  # We store this menu data in here to be used for both Desktop and Mobile navigation..
+  menus = [
+    {
+      label: 'Features',
+      rows: [
+        {
+          columns: [
+            {
+              label: 'Features',
+              links: [
+                {
+                  compact: true,
+                  icon: 'trend-up',
+                  icon_hover: 'chart-line-up-bold',
+                  title: 'Performance',
+                  href: '/TODO',
+                },
+                {
+                  compact: true,
+                  icon: 'coin',
+                  title: 'Dividends',
+                  href: '/TODO',
+                },
+                {
+                  compact: true,
+                  icon: 'receipt',
+                  icon_hover: 'article-fill',
+                  title: 'Tax Reporting',
+                  href: '/TODO',
+                }
+              ]
+            },
+            {
+              label: 'What we Track',
+              links: [
+                {
+                  compact: true,
+                  icon: 'squares-four',
+                  icon_hover: 'grid-four-fill',
+                  title: 'Supported Investments',
+                  href: '/TODO',
+                },
+                {
+                  compact: true,
+                  icon: 'globe-hemisphere-west',
+                  icon_hover: 'globe-hemisphere-east-fill',
+                  title: 'Supported Exchanges',
+                  href: '/TODO',
+                },
+                {
+                  compact: true,
+                  icon: 'bank',
+                  title: 'Supported Brokers',
+                  href: '/TODO',
+                }
+              ]
+            }
+          ]
+        },
+        {
+          class: 'menu__background',
+          columns: [
+            {
+              links: [
+                {
+                  icon: 'question',
+                  title: 'Frequently Asked Questions',
+                  href: '/faq',
+                },
+              ]
+            },
+            {
+              links: [
+                {
+                  icon: 'shield',
+                  icon_hover: 'shield-check-fill',
+                  title: 'Data Security',
+                  href: '/TODO',
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      label: 'Benefits',
+      rows: [
+        {
+          columns: [
+            {
+              links: [
+                {
+                  icon: 'user',
+                  title: 'Investors',
+                  href: '/TODO',
+                  description: 'Over 150,000 Investors around the world track their portfolios with Sharesight.'
+                },
+                {
+                  icon: 'users',
+                  title: 'Finance Professionals',
+                  href: '/TODO',
+                  description: 'Use Sharesight Pro to grow your business.'
+                },
+                {
+                  icon: 'buildings',
+                  title: 'Finance Companies',
+                  href: '/TODO',
+                  description: 'Partner with Sharesight and grow your business.'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      label: 'Pricing',
+      href: localize_url('pricing', locale_id: locale_obj[:id]),
+      title: locale_page(page: 'pricing', locale_obj: locale_obj)[:page_title],
+    },
+    {
+      label: 'Resources',
+      class: 'menu--lg',
+      rows: [
+        {
+          columns: [
+            {
+              label: 'Company',
+              links: [
+                {
+                  compact: true,
+                  icon: 'magnifying-glass',
+                  title: 'About Sharesight',
+                  href: '/TODO',
+                },
+                {
+                  compact: true,
+                  icon: 'user-rectangle',
+                  title: 'Executive Team',
+                  href: '/TODO',
+                },
+                {
+                  compact: true,
+                  icon: 'briefcase',
+                  title: 'Careers',
+                  href: '/TODO',
+                },
+                {
+                  compact: true,
+                  icon: 'megaphone-simple',
+                  title: 'Media Center',
+                  href: '/TODO',
+                },
+                {
+                  compact: true,
+                  icon: 'smiley',
+                  icon_hover: 'smiley-wink-fill',
+                  title: 'Reviews',
+                  href: '/TODO',
+                }
+              ],
+            }, {
+              label: 'Work with Us',
+              links: [
+                {
+                  compact: true,
+                  icon: 'identification-card',
+                  title: 'Partner Directory',
+                  href: '/TODO',
+                },
+                {
+                  compact: true,
+                  icon: 'handshake',
+                  title: 'Become a Partner',
+                  href: '/TODO',
+                },
+                {
+                  compact: true,
+                  icon: 'share-network',
+                  icon_hover: 'fire-fill',
+                  title: 'Become an Affiliate',
+                  href: '/TODO',
+                },
+                {
+                  compact: true,
+                  icon: 'envelope-simple',
+                  icon_hover: 'envelope-simple-open',
+                  title: 'sales@sharesight.com',
+                  href: 'mailto:sales@sharesight.com',
+                }
+              ]
+            }, {
+              label: 'Resources',
+              links: [
+                {
+                  compact: true,
+                  icon: 'info',
+                  title: 'Help Centre',
+                  href: '/TODO',
+                },
+                {
+                  compact: true,
+                  icon: 'code',
+                  title: 'Sharesight API',
+                  href: '/TODO',
+                },
+                {
+                  compact: true,
+                  icon: 'monitor-play',
+                  icon_hover: 'monitor-fill',
+                  title: 'Events & Webinars',
+                  href: '/TODO',
+                }
+              ]
+            }
+          ]
+        },
+        {
+          # For this row, we just use a specific blog partial rather than try to fit it into this format…
+          partial: 'partials/header/blog',
+        }
+      ]
+    }
+  ]
+%>
+
 <nav role="navigation" class="nav" aria-label="Sharesight" id="site_navigation" >
   <a href="<%= localize_url(locale_id: locale_obj[:id]) %>" id="site_logo" title="<%= locale_page(page: 'index', locale_obj: locale_obj)[:page_title] %>">
     <img src="<%=image_path('logos/logo.svg')%>" alt="<%= locale_obj[:default_title] %>" class="site_logo">
   </a>
 
-  <%= partial "partials/header/desktop_navigation" %>
+  <%= partial "partials/header/desktop_navigation", locals: { menus: menus } %>
 
   <a href="<%= config[:login_url] %>" class="nav__cta btn--transparent hide-mobile" title="Log in to Sharesight">Log in</a>
   <a href="<%= locals[:professional] ? config[:pro_signup_url] : config[:signup_url] %>" class="nav__cta btn--highlight" title="Sign Up for Sharesight for Free">
@@ -22,5 +250,5 @@
     <span class="show-desktop hide-mobile">Get Sharesight Free</span>
   </a>
 
-  <%= partial "partials/header/mobile_navigation" %>
+  <%= partial "partials/header/mobile_navigation", locals: { menus: menus } %>
 </nav>

--- a/source/partials/header/_row.html.erb
+++ b/source/partials/header/_row.html.erb
@@ -1,0 +1,19 @@
+<%
+  row = locals[:row]
+%>
+
+<div class="menu__row <%= row[:class] %>">
+  <% row[:columns].each do |column| %>
+    <div class="menu__split-<%= row[:columns].length %>">
+
+      <% if column[:label] %>
+        <div class="menu__title" role="separator"><%= column[:label] %></div>
+      <% end %>
+
+      <% column[:links].each do |link| %>
+        <%= partial "partials/header/link", locals: link %>
+      <% end %>
+
+    </div> <%# closes "menu__split-#" %>
+  <% end %> <%# ends row[:columns].each %>
+</div> <%# closes "menu__row" %>


### PR DESCRIPTION
See #248, this is an exploratory deviation from that—basically migrating spaghetti code into a bit less spaghetti…maybe it's just a different pasta.  Ruby isn't built for this.

---

This allows us to use the same menu items in both Mobile and Desktop as otherwise I think I'll just have to have `icon: '…', title:'…'` duplicated for every link in a lot of places..  @irwalker Is this a good approach..?  Do you think you could add/edit/modify a link in the future?  I would, of course, have test coverage that asserts 1:1 all of this as well…

I could probably even migrate this to a JSON format, if that helps…eg. use `title_from_page: 'pricing'` to execute on the fly, instead of `locale_page(page: 'pricing', locale_obj: locale_obj)[:page_title]` in instantiation…I think that maybe adds _more complexity_, not less.

Ideally I'd move this into another file, but I can't see how, eg. there are no controllers here…. I could move this into a helper, eg. `helpers/navigation_helper.rb` and have a method like `self.menu_definition` which returns this Array/Data Object.  Then I'd call it like `menu = NavigationHelper.menu_definition()`...  Is that a good idea?  Maybe that's a slightly easier way to test—I could assert like everything has a `columns` or whatnot, alongside some UI tests?  Basically, assert it matches an expected interface..

If this is the way, is there a `jsdoc` like way to document this?  This is a complex data structure; I'd like to define what a `menu` and a `row` and a `column` and a `link` could be…though maybe my test coverage above could really do that (but even then, it'd still be messy).


🤮 I hate Ruby syntax here…and this repo is so far off from being able to look at Ruby Components or whatever they call them, so I can't think of a much better way.

🤯 