### PR TITLE
Preload fonts and make the page progressively load faster.

### DIFF
--- a/source/css/elements/_base.scss
+++ b/source/css/elements/_base.scss
@@ -3,24 +3,28 @@
   src: url('../fonts/opensans-bold-webfont-webfont.woff') format('woff');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: 'Open Sans';
   src: url('../fonts/opensans-light-webfont-webfont.woff') format('woff');
   font-weight: 300;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: 'Open Sans';
   src: url('../fonts/opensans-regular-webfont-webfont.woff') format('woff');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: 'merriweatheritalic';
   src: url('../fonts/merriweather-italic-webfont.woff') format('woff');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 * {

--- a/source/layouts/partials/_head.html.erb
+++ b/source/layouts/partials/_head.html.erb
@@ -28,7 +28,15 @@
 
   <%= partial "layouts/partials/meta", locals: locals %>
 
-  <script>document.documentElement.className = document.documentElement.className.replace('no-js', 'js');</script>
+  <script>
+    document.documentElement.className = document.documentElement.className.replace('no-js', 'js');
+  </script>
+
+  <!-- Preload some fonts to be loaded in stylesheets -->
+  <link rel="preload" href="<%= asset_url("fonts/opensans-bold-webfont-webfont.woff") %>" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="<%= asset_url("fonts/opensans-light-webfont-webfont.woff") %>" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="<%= asset_url("fonts/opensans-regular-webfont-webfont.woff") %>" as="font" type="font/woff2" crossorigin>
+
   <%= stylesheet_link_tag "pro.css" if locals[:pro] == true %>
   <%= stylesheet_link_tag "site.css" %>
 </head>


### PR DESCRIPTION
[Vimaly Story](https://vimaly.com/#j8mqm/t/www_Preload_and_progressively_load_fonts_better./HvNZj0e8cyIAIagQq)

**Changes:**
 - Preload fonts as they are requested to load after `site.css` has loaded.  I did not preload all fonts, but the common ones.
 - Progressively load fonts rather than not painting (via `font-display: swap`).