### PR TITLE
Test and fix up the `blog_posts` helper method a bit.

### DIFF
--- a/helpers/middleman/blog.rb
+++ b/helpers/middleman/blog.rb
@@ -3,7 +3,7 @@ load File::expand_path('../blog_helper.rb', __dir__)
 
 module MiddlemanBlogHelpers
 
-  def blog_posts(order: nil)
+  def blog_posts(order: :latest_first)
     @blog_posts ||= {}
     return @blog_posts[order] if @blog_posts[order]
 

--- a/helpers/middleman/blog.rb
+++ b/helpers/middleman/blog.rb
@@ -10,11 +10,11 @@ module MiddlemanBlogHelpers
     @blog_posts[order] ||= case order
       when :oldest_first
         data.blog.posts.values.sort do |a,b|
-          a['created_at'].to_i <=> b['created_at'].to_i
+          a['created_at'] <=> b['created_at']
         end
       when :latest_first
         data.blog.posts.values.sort do |a,b|
-          b['created_at'].to_i <=> a['created_at'].to_i
+          b['created_at'] <=> a['created_at']
         end
       else
         data.blog.posts.values

--- a/helpers/middleman/blog.rb
+++ b/helpers/middleman/blog.rb
@@ -8,13 +8,13 @@ module MiddlemanBlogHelpers
     return @blog_posts[order] if @blog_posts[order]
 
     @blog_posts[order] ||= case order
-    when :latest_first
-        data.blog.posts.values.sort do |a,b|
-          a['created_at'] <=> b['created_at']
-        end
       when :oldest_first
         data.blog.posts.values.sort do |a,b|
-          b['created_at'] <=> a['created_at']
+          a['created_at'].to_i <=> b['created_at'].to_i
+        end
+      when :latest_first
+        data.blog.posts.values.sort do |a,b|
+          b['created_at'].to_i <=> a['created_at'].to_i
         end
       else
         data.blog.posts.values

--- a/helpers/middleman/blog.rb
+++ b/helpers/middleman/blog.rb
@@ -8,7 +8,7 @@ module MiddlemanBlogHelpers
     return @blog_posts[order] if @blog_posts[order]
 
     @blog_posts[order] ||= case order
-      when :youngest_first
+    when :latest_first
         data.blog.posts.values.sort do |a,b|
           a['created_at'] <=> b['created_at']
         end
@@ -17,7 +17,7 @@ module MiddlemanBlogHelpers
           b['created_at'] <=> a['created_at']
         end
       else
-        data.blog.posts
+        data.blog.posts.values
       end
   end
 

--- a/source/blog/feed.xml.builder
+++ b/source/blog/feed.xml.builder
@@ -8,7 +8,7 @@ xml.rss version: "2.0", 'xmlns:dc' => "http://purl.org/dc/elements/1.1/", 'xmlns
     xml.language "en-US"
 
     number_of_items = 10
-    blog_posts(order: :latest_first)[-number_of_items..-1].reverse.each do |post|
+    blog_posts(order: :latest_first)[0..number_of_items].each do |post|
       next if post[:title].blank?
       next if post[:hide_from_feed]
 

--- a/source/blog/feed.xml.builder
+++ b/source/blog/feed.xml.builder
@@ -8,7 +8,7 @@ xml.rss version: "2.0", 'xmlns:dc' => "http://purl.org/dc/elements/1.1/", 'xmlns
     xml.language "en-US"
 
     number_of_items = 10
-    blog_posts(order: :youngest_first)[-number_of_items..-1].reverse.each do |post|
+    blog_posts(order: :latest_first)[-number_of_items..-1].reverse.each do |post|
       next if post[:title].blank?
       next if post[:hide_from_feed]
 

--- a/source/blog/sitemap.xml.erb
+++ b/source/blog/sitemap.xml.erb
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
-  <% blog_posts(order: :latest_first).select{ |p| p[:created_at] && p[:title] }.take(2).each do |post| %>
-    <% if !post.title.blank? %>
-      <url>
-        <loc><%= post_url(post) %></loc>
-        <news:news>
-          <news:publication>
-            <news:name>Sharesight</news:name>
-            <news:language>en</news:language>
-          </news:publication>
-          <news:genres>Blog</news:genres>
-          <news:publication_date><%= Date.parse(post.created_at.to_s) %></news:publication_date>
-          <news:title><%=post.title.gsub('&','&amp;')%></news:title>
-        </news:news>
-      </url>
-    <%end%>
-  <%end%>
+  <% blog_posts(order: :latest_first).select{ |p| p[:title] }.take(2).each do |post| %>
+    <url>
+      <loc><%= post_url(post) %></loc>
+      <news:news>
+        <news:publication>
+          <news:name>Sharesight</news:name>
+          <news:language>en</news:language>
+        </news:publication>
+        <news:genres>Blog</news:genres>
+        <news:publication_date><%= Date.parse(post.created_at.to_s) %></news:publication_date>
+        <news:title><%=post.title.gsub('&','&amp;')%></news:title>
+      </news:news>
+    </url>
+  <% end %>
 </urlset>

--- a/source/blog/sitemap.xml.erb
+++ b/source/blog/sitemap.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
-  <% data&.blog&.posts&.map {|p| p[1] }.select{ |p| p[:created_at] && p[:title] }.sort_by { |p| p[:created_at] }.reverse.take(2).each do |post| %>
+  <% blog_posts(order: :latest_first).select{ |p| p[:created_at] && p[:title] }.take(2).each do |post| %>
     <% if !post.title.blank? %>
       <url>
         <loc><%= post_url(post) %></loc>

--- a/source/blog/sitemap.xml.erb
+++ b/source/blog/sitemap.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
-  <% blog_posts(order: :latest_first).select{ |post| post[:title]&.present? }.take(2).each do |post| %>
+  <% blog_posts(order: :latest_first).select{ |post| post[:title].present? }.take(2).each do |post| %>
     <url>
       <loc><%= post_url(post) %></loc>
       <news:news>

--- a/source/blog/sitemap.xml.erb
+++ b/source/blog/sitemap.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
-  <% blog_posts(order: :latest_first).select{ |p| p[:title] }.take(2).each do |post| %>
+  <% blog_posts(order: :latest_first).select{ |post| post[:title]&.present? }.take(2).each do |post| %>
     <url>
       <loc><%= post_url(post) %></loc>
       <news:news>

--- a/source/sitemap.xml.erb
+++ b/source/sitemap.xml.erb
@@ -16,7 +16,7 @@
   <% end %>
 
   <%# Iterates through every post. %>
-  <% blog_posts(order: :latest_first).select{ |post| post[:title]&.present? }.each do |post| %>
+  <% blog_posts(order: :latest_first).select{ |post| post[:title].present? }.each do |post| %>
     <% updated_at = post[:_meta][:updated_at] %>
     <url>
       <loc><%= post_url(post) %></loc>

--- a/source/sitemap.xml.erb
+++ b/source/sitemap.xml.erb
@@ -16,7 +16,7 @@
   <% end %>
 
   <%# Iterates through every post. %>
-  <% data.blog.posts.map{ |post| post[1] }.select{ |post| post[:title]&.present? }.each do |post| %>
+  <% blog_posts(order: :latest_first).select{ |post| post[:title]&.present? }.each do |post| %>
     <% updated_at = post[:_meta][:updated_at] %>
     <url>
       <loc><%= post_url(post) %></loc>

--- a/spec/features/blog_posts_page_spec.rb
+++ b/spec/features/blog_posts_page_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe 'Blog Post Pages', :type => :feature do
   before :all do
-    @posts = get_blog_posts(order: :youngest_first, limit: 10)
+    @posts = get_blog_posts(order: :latest_first, limit: 10)
     @categories = get_blog_categories(all: true)
   end
 

--- a/spec/helpers/blog_helper_spec.rb
+++ b/spec/helpers/blog_helper_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'Blog Helper', :type => :helper do
   before :all do
-    @posts = get_blog_posts(order: :youngest_first, limit: 10)
+    @posts = get_blog_posts(order: :latest_first, limit: 10)
   end
 
   context "url slug" do

--- a/spec/helpers/middleman/blog_spec.rb
+++ b/spec/helpers/middleman/blog_spec.rb
@@ -29,12 +29,10 @@ describe 'Blog Middleman Helper', :type => :helper do
     end
 
     it "is ordered by :latest_first by default" do
-      posts = @app.blog_posts()
+      posts_default = @app.blog_posts()
+      posts_latest_first = @app.blog_posts(order: :latest_first)
 
-      expect(posts.first[:created_at]).to be > posts[1][:created_at]
-      expect(posts.first[:created_at]).to be > posts[posts.length - 1][:created_at]
-
-      expect(posts.length).to eq(@total_blog_posts)
+      expect(posts_default).to eq(posts_latest_first)
     end
 
     it "can be ordered by :oldest_first" do

--- a/spec/helpers/middleman/blog_spec.rb
+++ b/spec/helpers/middleman/blog_spec.rb
@@ -17,7 +17,13 @@ describe 'Blog Middleman Helper', :type => :helper do
     it "can be ordered by :latest_first" do
       posts = @app.blog_posts(order: :latest_first)
 
-      expect(posts.first[:created_at]).to be > posts.last[:created_at]
+      # The newest blog post is probably always this or the previous year…probably.
+      expect(posts.first[:created_at].year).to be >= Time.now.year - 1
+      # The oldest blog post is from 2007.
+      expect(posts.last[:created_at].year).to be(2007)
+
+      expect(posts.first[:created_at].to_i).to be > posts[1][:created_at].to_i
+      expect(posts.first[:created_at].to_i).to be > posts[posts.length - 1][:created_at].to_i
 
       expect(posts.length).to eq(@total_blog_posts)
     end
@@ -34,8 +40,13 @@ describe 'Blog Middleman Helper', :type => :helper do
     it "can be ordered by :oldest_first" do
       posts = @app.blog_posts(order: :oldest_first)
 
-      expect(posts.first[:created_at]).to be < posts[1][:created_at]
-      expect(posts.first[:created_at]).to be < posts[posts.length - 1][:created_at]
+      # The oldest blog post is from 2007.
+      expect(posts.first[:created_at].year).to be(2007)
+      # The newest blog post is probably always this or the previous year…probably.
+      expect(posts.last[:created_at].year).to be >= Time.now.year - 1
+
+      expect(posts.first[:created_at].to_i).to be < posts[1][:created_at].to_i
+      expect(posts.first[:created_at].to_i).to be < posts[posts.length - 1][:created_at].to_i
 
       expect(posts.length).to eq(@total_blog_posts)
     end

--- a/spec/helpers/middleman/blog_spec.rb
+++ b/spec/helpers/middleman/blog_spec.rb
@@ -3,12 +3,58 @@ require 'spec_helper'
 describe 'Blog Middleman Helper', :type => :helper do
   before :all do
     @app = Capybara.app
+    @posts_data = Capybara.app.data.blog.posts.values
+    @total_blog_posts = @posts_data.length
+  end
+
+  context "blog_posts" do
+    it "should have the expected length of blog posts" do
+      posts = @app.blog_posts
+
+      expect(posts.length).to eq(@total_blog_posts)
+    end
+
+    it "can be ordered by :latest_first" do
+      posts = @app.blog_posts(order: :latest_first)
+
+      expect(posts.first[:created_at]).to be > posts.last[:created_at]
+
+      expect(posts.length).to eq(@total_blog_posts)
+    end
+
+    it "is ordered by :latest_first by default" do
+      posts = @app.blog_posts()
+
+      expect(posts.first[:created_at]).to be > posts[1][:created_at]
+      expect(posts.first[:created_at]).to be > posts[posts.length - 1][:created_at]
+
+      expect(posts.length).to eq(@total_blog_posts)
+    end
+
+    it "can be ordered by :oldest_first" do
+      posts = @app.blog_posts(order: :oldest_first)
+
+      expect(posts.first[:created_at]).to be < posts[1][:created_at]
+      expect(posts.first[:created_at]).to be < posts[posts.length - 1][:created_at]
+
+      expect(posts.length).to eq(@total_blog_posts)
+    end
+
+    it "can be unordered (no use-case)" do
+      posts = @app.blog_posts(order: nil)
+
+      # The unordered posts match the dataset (which may or may not have an order)
+      expect( posts[0][:id]).to eq(@posts_data[0][:id])
+      expect(posts[posts.length - 1][:id]).to eq(@posts_data[posts.length - 1][:id])
+
+      expect(posts.length).to eq(@total_blog_posts)
+    end
   end
 
   context "post_url" do
     # This is a proxy to other tested helpers.
     it "should return a string" do
-      get_blog_posts(order: :youngest_first, limit: 10).each do |post|
+      get_blog_posts(order: :latest_first, limit: 10).each do |post|
         expect(@app.post_url(post)).to be_kind_of(::String)
       end
     end

--- a/spec/helpers/middleman/space_spec.rb
+++ b/spec/helpers/middleman/space_spec.rb
@@ -17,7 +17,7 @@ describe 'Space Middleman Helper', :type => :helper do
     end
 
     it "should be Blog on the first valid post" do
-      post = get_blog_posts(order: :youngest_first, limit: 10).find{ |model| model[:title] }
+      post = get_blog_posts(order: :latest_first, limit: 10).find{ |model| model[:title] }
       visit '/blog/' + @app.post_url(post)
       expect(@app.is_category_page?).to eq(false)
     end
@@ -64,7 +64,7 @@ describe 'Space Middleman Helper', :type => :helper do
     end
 
     it "should be Blog on the first valid post" do
-      post = get_blog_posts(order: :youngest_first, limit: 10).find{ |model| model[:title] }
+      post = get_blog_posts(order: :latest_first, limit: 10).find{ |model| model[:title] }
       visit '/blog/' + @app.post_url(post)
       expect(@app.space_category_title).to eq('Blog')
     end
@@ -106,7 +106,7 @@ describe 'Space Middleman Helper', :type => :helper do
     end
 
     it "should be correct on the first valid post" do
-      post = get_blog_posts(order: :youngest_first, limit: 10).find{ |model| model[:title] }
+      post = get_blog_posts(order: :latest_first, limit: 10).find{ |model| model[:title] }
       visit '/blog/' + @app.post_url(post)
       expect(@app.space_category_page_title).to eq('Sharesight Blog')
     end
@@ -149,7 +149,7 @@ describe 'Space Middleman Helper', :type => :helper do
     end
 
     it "should be correct on the first valid post" do
-      post = get_blog_posts(order: :youngest_first, limit: 10).find{ |model| model[:title] }
+      post = get_blog_posts(order: :latest_first, limit: 10).find{ |model| model[:title] }
       visit '/blog/' + @app.post_url(post)
       expect(@app.base_space_category_page_title).to eq('Sharesight Blog')
     end

--- a/spec/models/blog_posts_spec.rb
+++ b/spec/models/blog_posts_spec.rb
@@ -38,7 +38,7 @@ describe 'Blog Posts', :type => :model do
 
     expect(schema).to include(
       :id, :_meta, :title, :content, :author, :categories, :created_at,
-      :meta_description, :featured_image, :wordpress_url
+      :meta_description, :featured_image, :hide_from_feed, :slug, :path, :url, :page_title
     )
   end
 end

--- a/spec/models/blog_posts_spec.rb
+++ b/spec/models/blog_posts_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Blog Posts', :type => :model do
   before :all do
     @data = Capybara.app.data.blog.posts
-    @collection = get_blog_posts(order: :youngest_first, limit: 10)
+    @collection = get_blog_posts(order: :latest_first, limit: 10)
   end
 
   it "should have a directory" do

--- a/spec/support/helpers/blog.rb
+++ b/spec/support/helpers/blog.rb
@@ -57,20 +57,7 @@ module CapybaraBlogHelpers
   private
 
   def _blog_posts(order: nil, limit: nil)
-    posts = Capybara.app.data.blog.posts.map{ |tuple| tuple[1] }
-
-    case order
-    when :youngest_first
-      posts.sort do |a,b|
-        a['created_at'] <=> b['created_at']
-      end
-    when :oldest_first
-      posts.sort do |a,b|
-        b['created_at'] <=> a['created_at']
-      end
-    else
-      posts
-    end
+    posts = Capybara.app.blog_posts(order: order)
 
     if limit
       posts = posts[0..limit]


### PR DESCRIPTION
[Vimaly Story](https://vimaly.com/#j8mqm/t/www_Minor_tweaks_to_blog_post_ordering_in_a_few_pl.../65o9rq2eXYYj31kL5)

NOTE: This is included in #248 

This was originally done in https://github.com/sharesight/www.sharesight.com/pull/72 and used to limit them amount of blog posts we link to and test against.

Done in this:
 - I renamed `youngest_first` to `latest_first`.  I was confused which was which and I think this makes it clearer?
 - BugFix: The `order: nil` scenario was returning tuples, not post objects.
 - Cleanup: using the internal helper inside of the `_blog_posts` rspec helper.
 - Add some test coverage as, again, I wasn't sure which was which without it!
 - BugFix: `oldest_first` and `youngest_first` (from the original PR) were actually opposite of their naming…?
 - Being a bit more consistent with using the `blog_posts` helper.