### PR TITLE
When getting a Landing Page, use the locale so we get the right title.

### DIFF
--- a/helpers/middleman/landing-pages.rb
+++ b/helpers/middleman/landing-pages.rb
@@ -21,13 +21,16 @@ module MiddlemanLandingPagesHelpers
     lang = locale_obj[:lang]
 
     @landing_pages_collection ||= {}
-    @landing_pages_collection[lang] ||= app_data['landing-pages'].pages.map do |tuple|
-      model = tuple[1] # contentful passes ["id", { ... }]
+
+    # We use `.values` as contentful passes a tuple of ["id", { …model… }]
+    @landing_pages_collection[lang] ||= app_data['landing-pages'].pages.values.reject do |model|
+      model[:url_slug].blank?
+    end.map do |model|
       localized_model = localize_entry(model, lang, default_locale_obj[:lang])
       localized_model[:page_title] = landing_page_title(localized_model, locale_obj: locale_obj)
       localized_model[:description] = localized_model[:page_description]
 
       localized_model
-    end.reject{ |model| model[:url_slug].blank? }
+    end
   end
 end

--- a/helpers/middleman/locale.rb
+++ b/helpers/middleman/locale.rb
@@ -27,7 +27,7 @@ module MiddlemanLocaleHelpers
     return current_locale_id == locale_id
   end
 
-  def get_locale_obj(locale_id = current_locale_id )
+  def get_locale_obj(locale_id = current_locale_id)
     locale_id = locale_id&.downcase
 
     locale_obj = data.locales.find { |x| x[:id] == locale_id }

--- a/helpers/middleman/page.rb
+++ b/helpers/middleman/page.rb
@@ -47,7 +47,7 @@ module MiddlemanPageHelpers
     page = page&.downcase&.sub(/\.html$/, '')
 
     # Look through the current locale's pages for the page; if not found, look in the default locale's pages; return the output.
-    found_page = locale_obj.pages.find{ |y| y[:page] == page }
+    found_page = locale_obj[:pages].find{ |y| y[:page] == page }
 
     if found_page.nil?
       # Not found, find the first one where the page is found.
@@ -56,7 +56,7 @@ module MiddlemanPageHelpers
     end
 
     if found_page.nil?
-      found_page = get_landing_page(page)
+      found_page = get_landing_page(page, locale_obj: locale_obj)
     end
 
     return found_page # may return a nil here!
@@ -64,7 +64,7 @@ module MiddlemanPageHelpers
 
   def page_alternative_locales(page_name = valid_page_from_path)
     return false if !is_valid_page?(page_name)
-    return data.locales if get_landing_page(page_name)
+    return data.locales if get_landing_page(page_name, locale_obj: default_locale_obj)
 
     @page_alternative_locales ||= data.locales.reduce({}) do |hash, locale|
       locale.pages.each do |page_data|
@@ -92,7 +92,7 @@ module MiddlemanPageHelpers
   end
 
   def is_landing_page?(page_name = valid_page_from_path)
-    return !!get_landing_page(page_name)
+    return !!get_landing_page(page_name, locale_obj: default_locale_obj)
   end
 
   def is_valid_locale_id_for_page?(page_name, locale_id)
@@ -119,8 +119,8 @@ module MiddlemanPageHelpers
     return locales[0]
   end
 
-  def get_landing_page(page_name = valid_page_from_path)
-    found = landing_pages_collection.find{ |page| page.url_slug == page_name }
+  def get_landing_page(page_name = valid_page_from_path, locale_obj: current_locale_obj)
+    found = landing_pages_collection(locale_obj: locale_obj).find{ |page| page.url_slug == page_name }
     return unless found
 
     found.with_indifferent_access

--- a/source/sitemap.xml.erb
+++ b/source/sitemap.xml.erb
@@ -67,7 +67,7 @@
 <%end%>
 
 <%# Iterates through every landing page. %>
-<% landing_pages_collection().select{ |landing_page| landing_page[:no_index] != true }.each do |landing_page| %>
+<% landing_pages_collection(locale_obj: locale_obj).select{ |landing_page| landing_page[:no_index] != true }.each do |landing_page| %>
   <% updated_at = landing_page[:_meta][:updated_at] %>
 
   <url>

--- a/spec/features/footer_spec.rb
+++ b/spec/features/footer_spec.rb
@@ -1,8 +1,11 @@
 require 'spec_helper'
 
 describe 'Footer', type: :feature do
-  it 'should have all expected links' do
+  before :each do
     visit '/'
+  end
+
+  it 'should have all expected links' do
     links = page.all(:css, 'a.footer__link')
 
     expected_links = [
@@ -60,5 +63,36 @@ describe 'Footer', type: :feature do
 
 
     expect(expected_links.length).to(eq(0), "Found leftover links in expected_links: #{expected_links}")
+  end
+
+  Capybara.app.data.locales.each do |locale_obj|
+    [
+      ['About Us', 'About Us'], # page from codebase
+      ['Become a Partner', 'Partner with Sharesight'], # page from Contentful. NOTE: This may change!
+      ['Help Centre', 'Help Centre'], # manual title w/ manual localization
+      ['Blog', 'Sharesight Blog', true], # hardcoded title, no localization
+      ['sales@sharesight.com', 'Email the Sales & Partnerships Team', true], # hardcoded title, no localization
+      ['Sharesight API', 'Sharesight API Documentation', true], # hardcoded title, no localization
+    ].each do |label, title, ignore_localization|
+      it "#{locale_obj[:country]} should have an an expected, localized title for #{label}" do
+        visit locale_obj[:path]
+
+        links = page.all(:css, 'a.footer__link')
+        link = links.find do |link|
+          link.text.include?(label)
+        end
+
+        raise "Could not find label: #{label} in #{locale_obj[:id]}!" unless link
+
+        title_localized = if ignore_localization
+          title
+        else
+          "#{title} | #{locale_obj[:append_title]}"
+        end
+
+        expect(link.text).to eq(label)
+        expect(link[:title]).to eq(title_localized)
+      end
+    end
   end
 end

--- a/spec/helpers/middleman/page_spec.rb
+++ b/spec/helpers/middleman/page_spec.rb
@@ -174,9 +174,37 @@ describe 'Page Helper', :type => :helper do
       expect(@app.locale_page(page: 'index')[:page]).to eq('index')
       expect(@app.locale_page(page: 'blog')[:page]).to eq('blog')
       expect(@app.locale_page(page: 'pro')[:page]).to eq('pro')
-      expect(@app.locale_page(page: 'pro', locale_obj: @app.get_locale_obj('nz'))[:page]).to eq('pro')
+      expect(@app.locale_page(page: 'about-sharesight')[:page]).to eq('about-sharesight') # landing page
+    end
 
-      expect(@app.locale_page(page: 'fake-page')).to eq(nil)
+    it "should respond with a localized 'code' based page" do
+      expect(@app.locale_page(page: 'pro')[:page_title]).to eq('Sharesight Pro')
+      expect(@app.locale_page(page: 'pro', locale_obj: @app.get_locale_obj('global'))[:page_title]).to eq('Sharesight Pro')
+      expect(@app.locale_page(page: 'pro', locale_obj: @app.get_locale_obj('au'))[:page_title]).to eq('Sharesight Pro Australia')
+      expect(@app.locale_page(page: 'pro', locale_obj: @app.get_locale_obj('ca'))[:page_title]).to eq('Sharesight Pro Canada')
+      expect(@app.locale_page(page: 'pro', locale_obj: @app.get_locale_obj('nz'))[:page_title]).to eq('Sharesight Pro New Zealand')
+      expect(@app.locale_page(page: 'pro', locale_obj: @app.get_locale_obj('uk'))[:page_title]).to eq('Sharesight Pro UK')
+    end
+
+    it "should respond with a localized 'landing_page' based page" do
+      expect(@app.locale_page(page: 'about-sharesight')[:page_title]).to eq('About Us | Sharesight')
+      expect(@app.locale_page(page: 'about-sharesight', locale_obj: @app.get_locale_obj('global'))[:page_title]).to eq('About Us | Sharesight')
+      expect(@app.locale_page(page: 'about-sharesight', locale_obj: @app.get_locale_obj('au'))[:page_title]).to eq('About Us | Sharesight Australia')
+      expect(@app.locale_page(page: 'about-sharesight', locale_obj: @app.get_locale_obj('ca'))[:page_title]).to eq('About Us | Sharesight Canada')
+      expect(@app.locale_page(page: 'about-sharesight', locale_obj: @app.get_locale_obj('nz'))[:page_title]).to eq('About Us | Sharesight New Zealand')
+      expect(@app.locale_page(page: 'about-sharesight', locale_obj: @app.get_locale_obj('uk'))[:page_title]).to eq('About Us | Sharesight UK')
+    end
+
+    it "should return a page from the global locale when it doesn't exist on the requested locale" do
+      expect(@app.locale_page(page: 'survey-thanks')[:page_title]).to eq("Thanks | Sharesight")
+
+      # This page is special in that it doesn't have a localized version…
+      expect(@app.locale_page(page: 'survey-thanks', locale_obj: @app.get_locale_obj('nz'))[:page_title]).to eq("Thanks | Sharesight")
+      expect(@app.locale_page(page: 'survey-thanks', locale_obj: @app.get_locale_obj('uk'))[:page_title]).to eq("Thanks | Sharesight")
+    end
+
+    it "should respond with nil when no page is found" do
+      expect(@app.locale_page(page: 'unknown-page')).to eq(nil)
     end
   end
 


### PR DESCRIPTION
[Vimaly Ticket](https://vimaly.com/#j8mqm/t/www_Landing_Page_titles_arent_localized_in_other_p.../rMgOv9gFO346FDurV)

NOTE: This is included in #248 as I noticed we were getting incorrect titles.

---

Previously, we would do a `get_landing_page('faq')` and we'd get back the global page, so the title would be "Frequently Asked Questions | Sharesight".  The same would be for any locale.  We want "Frequently Asked Questions | Sharesight NZ" (etc).

This is visible in the Footer currently and was problematic in the Header as well.

 - Minor cleanup to the `landing_pages_collection` as we can `.reject` first if we de-tuple it with `.values`.  Should be more performant and readable.
 - A fair bit of test coverage!