### PR TITLE
Use `no_index` instead of `show_in_sitemap` to not index at the page level as well as the sitemap..

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -160,6 +160,9 @@ configure :build do
   activate :asset_hash, :ignore => [/touch-icon/, /opengraph/]
 
   activate :minify_html do |html|
+    html.remove_comments = config[:env_name] == 'production'
+    html.preserve_line_breaks = config[:env_name] != 'production'
+
     html.remove_http_protocol    = false
     html.remove_input_attributes = false
     html.remove_quotes           = true

--- a/data/locales.json
+++ b/data/locales.json
@@ -97,14 +97,14 @@
         "page_title": "Referral Program Terms and Conditions | Sharesight",
         "page_description": "Terms and Conditions applying to the Referral Program for Sharesight. Using the Sharesight Referral Program means you agree to these Terms.",
         "footer_tagline": "Simply the best portfolio management tool for DIY investors.",
-        "show_in_sitemap": false
+        "no_index": true
       },
       {
         "page": "404",
         "page_title": "Page Not Found | Sharesight",
         "page_description": "The leading online stock portfolio tracker & reporting tool for DIY investors. Track prices, trades, dividends, performance and tax!",
         "footer_tagline": "Simply the best portfolio management tool for DIY investors.",
-        "show_in_sitemap": false
+        "no_index": true
       },
       {
         "page": "xero",
@@ -118,7 +118,7 @@
         "page_title": "Thanks | Sharesight",
         "page_description": "Thanks for taking the time to complete our survey.",
         "footer_tagline": "Simply the best portfolio management tool for DIY investors.",
-        "show_in_sitemap": false
+        "no_index": true
       },
       {
         "page": "pro",
@@ -211,14 +211,14 @@
         "page_title": "Referral Program Terms and Conditions | Sharesight Australia",
         "page_description": "Terms and Conditions applying to the Referral Program for Sharesight Australia. Using the Sharesight Referral Program means you agree to these Terms.",
         "footer_tagline": "Simply the best portfolio management tool for Australian DIY investors.",
-        "show_in_sitemap": false
+        "no_index": true
       },
       {
         "page": "404",
         "page_title": "Page Not Found | Sharesight Australia",
         "page_description": "The leading online share portfolio tracker & reporting tool for Australian DIY investors. Track share prices, trades, dividends, performance and tax!",
         "footer_tagline": "Simply the best portfolio management tool for Australian DIY investors.",
-        "show_in_sitemap": false
+        "no_index": true
       },
       {
         "page": "xero",
@@ -318,14 +318,14 @@
         "page_title": "Referral Program Terms and Conditions | Sharesight Canada",
         "page_description": "Terms and Conditions applying to the Referral Program for Sharesight Canada. Using the Sharesight Referral Program means you agree to these Terms.",
         "footer_tagline": "Simply the best portfolio management tool for Canadian DIY investors.",
-        "show_in_sitemap": false
+        "no_index": true
       },
       {
         "page": "404",
         "page_title": "Page Not Found | Sharesight Canada",
         "page_description": "The leading online stock portfolio tracker & reporting tool for Canadian DIY investors. Track prices, trades, dividends, performance and tax!",
         "footer_tagline": "Simply the best portfolio management tool for Canadian DIY investors.",
-        "show_in_sitemap": false
+        "no_index": true
       },
       {
         "page": "xero",
@@ -425,14 +425,14 @@
         "page_title": "Referral Program Terms and Conditions | Sharesight New Zealand",
         "page_description": "Terms and Conditions applying to the Referral Program for Sharesight New Zealand. Using the Sharesight Referral Program means you agree to these Terms.",
         "footer_tagline": "Simply the best portfolio management tool for New Zealand DIY investors.",
-        "show_in_sitemap": false
+        "no_index": true
       },
       {
         "page": "404",
         "page_title": "Page Not Found | Sharesight New Zealand",
         "page_description": "The leading online share portfolio tracker & reporting tool for New Zealand DIY investors. Track share prices, trades, dividends, performance and tax!",
         "footer_tagline": "Simply the best portfolio management tool for New Zealand DIY investors.",
-        "show_in_sitemap": false
+        "no_index": true
       },
       {
         "page": "xero",
@@ -533,14 +533,14 @@
         "page_title": "Referral Program Terms and Conditions | Sharesight UK",
         "page_description": "Terms and Conditions applying to the Referral Program for Sharesight UK. Using the Sharesight Referral Program means you agree to these Terms.",
         "footer_tagline": "Simply the best portfolio management tool for UK DIY investors.",
-        "show_in_sitemap": false
+        "no_index": true
       },
       {
         "page": "404",
         "page_title": "Page Not Found | Sharesight UK",
         "page_description": "The leading online share portfolio tracker & reporting tool for UK DIY investors. Track share prices, trades, dividends, performance and tax!",
         "footer_tagline": "Simply the best portfolio management tool for UK DIY investors.",
-        "show_in_sitemap": false
+        "no_index": true
       },
       {
         "page": "xero",

--- a/source/layouts/partials/_meta.html.erb
+++ b/source/layouts/partials/_meta.html.erb
@@ -41,6 +41,13 @@
     metas[:no_index]           = current_locale_page[:no_index]
   end
 
+  # NOTE: We have this strictly because we don't index or follow non-production pages!!
+  # WARNING: This is not tested very well—our tests only assert "NoIndex, NoFollow" because mocking production would be annoying…
+  raw_robots_content = "Index, Follow"
+  raw_robots_content = "NoIndex" if metas[:no_index]
+  robots_content = raw_robots_content
+  robots_content = "NoIndex, NoFollow" if config[:env_name] != 'production'
+
   pagination = locals[:pagination]
   if pagination && pagination&.current_page && pagination&.total_pages && pagination&.current_page > 1
     # metas[:description]          = "#{pagination.from_items}-#{pagination.to_items} of (#{pagination.total_items}) – #{metas[:description]}"
@@ -60,13 +67,10 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 
-<% if config[:env_name] != 'production' # don't index or follow non-production pages %>
-  <meta name="robots" content="NoIndex, NoFollow">
-<% elsif metas[:no_index] # explicitly don't index this page %>
-  <meta name="robots" content="NoIndex">
-<% else %>
-  <meta name="robots" content="Index, Follow">
+<% if config[:env_name] != 'production'  %>
+  <!-- [<%= config[:env_name] %> override] If merged into production, this would be: "<%= raw_robots_content %>" -->
 <% end %>
+<meta name="robots" content="<%= robots_content %>">
 
 <meta name="msvalidate.01" content="D71EF5876D9C5F2034E74AC314553CA3" />
 

--- a/source/robots.txt.erb
+++ b/source/robots.txt.erb
@@ -11,7 +11,7 @@ Disallow: /
 <% end %>
 
 <% data.locales.each do |locale| %>
-  <% locale.pages.select{ |locale_page| locale_page[:show_in_sitemap] == false }.each do |locale_page| %>
+  <% locale.pages.select{ |locale_page| locale_page[:no_index] == true }.each do |locale_page| %>
 Disallow: <%= localize_path(locale_page[:page], locale_id: locale[:id]) %>
   <% end %>
 <% end %>

--- a/source/sitemap.xml.erb
+++ b/source/sitemap.xml.erb
@@ -86,7 +86,7 @@
 <%end%>
 
 <%# This is a list of pages on this current locale %>
-<% locale_obj[:pages].reject{ |page| page.show_in_sitemap == false }.each do |page_data| %>
+<% locale_obj[:pages].reject{ |page| page[:no_index] == true }.each do |page_data| %>
   <% alternative_locales = page_alternative_locales(page_data[:page]) %>
   <url>
     <%# Some pages can be strictly non-global, eg. a canadian landing page, so grabs the first locale. %>

--- a/spec/features/sitemap_spec.rb
+++ b/spec/features/sitemap_spec.rb
@@ -33,7 +33,7 @@ describe 'Sitemap', :type => :feature do
       visit localize_path('sitemap.xml', locale_id: locale[:id])
 
       expectation = 0
-      expectation += locale[:pages].reject{ |page| page.show_in_sitemap == false }.length
+      expectation += locale[:pages].reject{ |page| page[:no_index] == true }.length
 
       expectation += get_blog_posts().length if locale[:id] == default_locale_id
       expectation += get_blog_categories().length if locale[:id] == default_locale_id
@@ -41,7 +41,7 @@ describe 'Sitemap', :type => :feature do
       expectation += get_partners_partners(locale).length
       expectation += get_partners_categories(all: false).length
 
-      expectation += get_landing_pages(locale).reject { |lp| lp[:no_index] }.length
+      expectation += get_landing_pages(locale).reject { |lp| lp[:no_index] == true }.length
 
       expect(all(:xpath, '//urlset/url').length).to eq(expectation)
       expect(all(:xpath, '//urlset/url/loc').length).to eq(expectation)
@@ -135,7 +135,9 @@ describe 'Sitemap', :type => :feature do
         url = localize_url("/#{page_data.page}", locale_id: locale.id)
         xpath = generate_xpath('//urlset/url/loc', text: url)
 
-        unless page_data.show_in_sitemap == false
+        if page_data[:no_index] == true
+          expect(page).not_to have_xpath(xpath)
+        else
           expect(page).to have_xpath(xpath)
         end
       end

--- a/spec/support/rspec.rb
+++ b/spec/support/rspec.rb
@@ -29,7 +29,7 @@ RSpec::Matchers.define :have_base_metas do
   match do |page|
     expect(page).to have_meta('utf-8', name_key: 'charset')
     expect(page).to have_meta('viewport')
-    expect(page).to have_meta('robots')
+    expect(page).to have_meta('robots', 'NoIndex, NoFollow') # NOTE: This is because this env is not production; see the _meta.html.erb where this is defined.
     expect(page).to have_meta('application-name', 'Sharesight')
   end
 


### PR DESCRIPTION
Following on from #255, fixing up a bug we found with this [Vimaly Story](https://vimaly.com/#j8mqm/t/Make_referral_program_T_C_page_noindex/NhY77bUbYPSOne635).

Uses the more consistent `no_index` from the landing pages.  While the robots.txt and sitemap.xml were good, the page `<meta name="robots" content="…" />` was not so good.