### PR TITLE
Update Supported Brokers link.

### DIFF
--- a/helpers/middleman/menu.rb
+++ b/helpers/middleman/menu.rb
@@ -68,7 +68,7 @@ module MiddlemanMenuHelpers
                   icon: 'bank',
                   label: 'Supported Brokers',
                   title: "Supported Brokers | #{locale_obj[:append_title]}",
-                  href: localize_url('supported_brokers', locale_id: locale_obj[:id], base_url: config[:help_url]),
+                  href: localize_url('supported-brokers', locale_id: locale_obj[:id], base_url: config[:help_url]),
                 }
               ]
             }

--- a/source/partials/faqs/_how_do_i_import_my_stock_portfolio.html.erb
+++ b/source/partials/faqs/_how_do_i_import_my_stock_portfolio.html.erb
@@ -1,2 +1,2 @@
 <p>You can import your trading history via CSV (Excel) or simply by entering trades manually.</p>
-<p>We also integrate with a growing list of <a href="<%= localize_url('supported_brokers', locale_id: locale_obj[:id], base_url: config[:help_url]) %>" title="List of Supported Brokers">online brokers</a> which allows you to automatically import and track all your trading history in just a few clicks.</p>
+<p>We also integrate with a growing list of <a href="<%= localize_url('supported-brokers', locale_id: locale_obj[:id], base_url: config[:help_url]) %>" title="List of Supported Brokers">online brokers</a> which allows you to automatically import and track all your trading history in just a few clicks.</p>

--- a/source/partials/faqs/_how_do_i_keep_my_investments_in_sharesight_up_to_date.html.erb
+++ b/source/partials/faqs/_how_do_i_keep_my_investments_in_sharesight_up_to_date.html.erb
@@ -2,5 +2,5 @@
   Simply add your buy and sell transactions — Sharesight automatically records any corporate actions, including dividends, share splits, and capital returns. But don’t worry, you’re able to edit all automatically populated data.
 </p>
 <p>
-An easy way to keep-up with your buy and sell transactions is to have your broker forward trade confirmation emails to your unique Sharesight email address. Sharesight will instantly record the transactions and save the PDFs in your portfolio. This feature is currently available for over <a href="<%= localize_url('supported_brokers', locale_id: locale_obj[:id], base_url: config[:help_url]) %>" title="List of Supported Brokers">150+ online brokers</a>.
+An easy way to keep-up with your buy and sell transactions is to have your broker forward trade confirmation emails to your unique Sharesight email address. Sharesight will instantly record the transactions and save the PDFs in your portfolio. This feature is currently available for over <a href="<%= localize_url('supported-brokers', locale_id: locale_obj[:id], base_url: config[:help_url]) %>" title="List of Supported Brokers">150+ online brokers</a>.
 </p>

--- a/spec/features/header_spec.rb
+++ b/spec/features/header_spec.rb
@@ -29,7 +29,7 @@ describe 'Header', type: :feature do
             ["Tax Reporting", localize_path('investment-portfolio-tax', locale_id: locale_obj[:id])],
             ["Supported Investments", localize_path('faq', locale_id: locale_obj[:id]) + "#what-can-i-track-in-sharesight"],
             ["Supported Exchanges", localize_path('faq', locale_id: locale_obj[:id]) + "#which-stock-exchanges-does-sharesight-support"],
-            ["Supported Brokers", localize_url('supported_brokers', locale_id: locale_obj[:id], base_url: Capybara.app.config[:help_url])],
+            ["Supported Brokers", localize_url('supported-brokers', locale_id: locale_obj[:id], base_url: Capybara.app.config[:help_url])],
             ["Frequently Asked Questions", localize_path('faq', locale_id: locale_obj[:id])],
             ["Data Security", localize_url('how-sharesight-protects-your-data', locale_id: locale_obj[:id], base_url: Capybara.app.config[:help_url])],
 
@@ -185,7 +185,7 @@ describe 'Header', type: :feature do
             ["Tax Reporting", localize_path('investment-portfolio-tax', locale_id: locale_obj[:id])],
             ["Supported Investments", localize_path('faq', locale_id: locale_obj[:id]) + "#what-can-i-track-in-sharesight"],
             ["Supported Exchanges", localize_path('faq', locale_id: locale_obj[:id]) + "#which-stock-exchanges-does-sharesight-support"],
-            ["Supported Brokers", localize_url('supported_brokers', locale_id: locale_obj[:id], base_url: Capybara.app.config[:help_url])],
+            ["Supported Brokers", localize_url('supported-brokers', locale_id: locale_obj[:id], base_url: Capybara.app.config[:help_url])],
             ["Pricing", localize_path('pricing', locale_id: locale_obj[:id])], # NOTE: Mobile-only!
             ["Frequently Asked Questions", localize_path('faq', locale_id: locale_obj[:id])],
             ["Data Security", localize_url('how-sharesight-protects-your-data', locale_id: locale_obj[:id], base_url: Capybara.app.config[:help_url])],


### PR DESCRIPTION
Story: https://vimaly.com/#j8mqm/t/www_Update_nav_link_for_Supported_Brokers/kqBuD7LZNh0wxk1ss

Don't ask me why we have two, but https://help.sharesight.com/au/supported-brokers/ is better than https://help.sharesight.com/au/supported_brokers/

---

Also noticed that we have old FAQs which I changed in here.  I deleted those in https://github.com/sharesight/www.sharesight.com/pull/265, which required a manual commit into _develop_ (e1f24bfb)