### PR TITLE
Rename [add a redirect for] "Accounting Software" to "Software Providers".

### DIFF
--- a/s3/production-redirection-rules.json
+++ b/s3/production-redirection-rules.json
@@ -305,5 +305,50 @@
       "HostName": "www.sharesight.com",
       "ReplaceKeyPrefixWith": "ca/partners/jarden-direct"
     }
+  },
+  {
+    "Condition": {
+      "KeyPrefixEquals": "partners/accounting-software"
+    },
+    "Redirect": {
+      "HostName": "www.sharesight.com",
+      "ReplaceKeyPrefixWith": "partners/software-providers"
+    }
+  },
+  {
+    "Condition": {
+      "KeyPrefixEquals": "nz/partners/accounting-software"
+    },
+    "Redirect": {
+      "HostName": "www.sharesight.com",
+      "ReplaceKeyPrefixWith": "nz/software-providers"
+    }
+  },
+  {
+    "Condition": {
+      "KeyPrefixEquals": "au/partners/accounting-software"
+    },
+    "Redirect": {
+      "HostName": "www.sharesight.com",
+      "ReplaceKeyPrefixWith": "au/software-providers"
+    }
+  },
+  {
+    "Condition": {
+      "KeyPrefixEquals": "uk/partners/accounting-software"
+    },
+    "Redirect": {
+      "HostName": "www.sharesight.com",
+      "ReplaceKeyPrefixWith": "uk/software-providers"
+    }
+  },
+  {
+    "Condition": {
+      "KeyPrefixEquals": "ca/partners/accounting-software"
+    },
+    "Redirect": {
+      "HostName": "www.sharesight.com",
+      "ReplaceKeyPrefixWith": "ca/software-providers"
+    }
   }
 ]

--- a/s3/production-redirection-rules.json
+++ b/s3/production-redirection-rules.json
@@ -321,7 +321,7 @@
     },
     "Redirect": {
       "HostName": "www.sharesight.com",
-      "ReplaceKeyPrefixWith": "nz/software-providers"
+      "ReplaceKeyPrefixWith": "nz/partners/software-providers"
     }
   },
   {
@@ -330,7 +330,7 @@
     },
     "Redirect": {
       "HostName": "www.sharesight.com",
-      "ReplaceKeyPrefixWith": "au/software-providers"
+      "ReplaceKeyPrefixWith": "au/partners/software-providers"
     }
   },
   {
@@ -339,7 +339,7 @@
     },
     "Redirect": {
       "HostName": "www.sharesight.com",
-      "ReplaceKeyPrefixWith": "uk/software-providers"
+      "ReplaceKeyPrefixWith": "uk/partners/software-providers"
     }
   },
   {
@@ -348,7 +348,7 @@
     },
     "Redirect": {
       "HostName": "www.sharesight.com",
-      "ReplaceKeyPrefixWith": "ca/software-providers"
+      "ReplaceKeyPrefixWith": "ca/partners/software-providers"
     }
   }
 ]

--- a/s3/staging-redirection-rules.json
+++ b/s3/staging-redirection-rules.json
@@ -305,5 +305,50 @@
       "HostName": "staging-www.sharesight.com",
       "ReplaceKeyPrefixWith": "ca/partners/jarden-direct"
     }
+  },
+  {
+    "Condition": {
+      "KeyPrefixEquals": "partners/accounting-software"
+    },
+    "Redirect": {
+      "HostName": "staging-www.sharesight.com",
+      "ReplaceKeyPrefixWith": "partners/software-providers"
+    }
+  },
+  {
+    "Condition": {
+      "KeyPrefixEquals": "nz/partners/accounting-software"
+    },
+    "Redirect": {
+      "HostName": "staging-www.sharesight.com",
+      "ReplaceKeyPrefixWith": "nz/software-providers"
+    }
+  },
+  {
+    "Condition": {
+      "KeyPrefixEquals": "au/partners/accounting-software"
+    },
+    "Redirect": {
+      "HostName": "staging-www.sharesight.com",
+      "ReplaceKeyPrefixWith": "au/software-providers"
+    }
+  },
+  {
+    "Condition": {
+      "KeyPrefixEquals": "uk/partners/accounting-software"
+    },
+    "Redirect": {
+      "HostName": "staging-www.sharesight.com",
+      "ReplaceKeyPrefixWith": "uk/software-providers"
+    }
+  },
+  {
+    "Condition": {
+      "KeyPrefixEquals": "ca/partners/accounting-software"
+    },
+    "Redirect": {
+      "HostName": "staging-www.sharesight.com",
+      "ReplaceKeyPrefixWith": "ca/software-providers"
+    }
   }
 ]

--- a/s3/staging-redirection-rules.json
+++ b/s3/staging-redirection-rules.json
@@ -321,7 +321,7 @@
     },
     "Redirect": {
       "HostName": "staging-www.sharesight.com",
-      "ReplaceKeyPrefixWith": "nz/software-providers"
+      "ReplaceKeyPrefixWith": "nz/partners/software-providers"
     }
   },
   {
@@ -330,7 +330,7 @@
     },
     "Redirect": {
       "HostName": "staging-www.sharesight.com",
-      "ReplaceKeyPrefixWith": "au/software-providers"
+      "ReplaceKeyPrefixWith": "au/partners/software-providers"
     }
   },
   {
@@ -339,7 +339,7 @@
     },
     "Redirect": {
       "HostName": "staging-www.sharesight.com",
-      "ReplaceKeyPrefixWith": "uk/software-providers"
+      "ReplaceKeyPrefixWith": "uk/partners/software-providers"
     }
   },
   {
@@ -348,7 +348,7 @@
     },
     "Redirect": {
       "HostName": "staging-www.sharesight.com",
-      "ReplaceKeyPrefixWith": "ca/software-providers"
+      "ReplaceKeyPrefixWith": "ca/partners/software-providers"
     }
   }
 ]


### PR DESCRIPTION
See: https://vimaly.com/#j8mqm/t/www_partner_directory_Rename_Accounting_Software_s.../5ArzAEDkEqqPZ30PV

 - This change is actually manually done in AWS S3 > Properties > Bucket Properties..  This is just where we [hopefully] store the latest version of that config.
 - This requires a Contentful change to be valid…the redirect will 404 until the Contentful is updated (or the old links will 404 if the redirect does not exist).