### PR TITLE
Use greater/less than equal instead of greater/less than.

### DIFF
--- a/spec/helpers/middleman/blog_spec.rb
+++ b/spec/helpers/middleman/blog_spec.rb
@@ -22,8 +22,8 @@ describe 'Blog Middleman Helper', :type => :helper do
       # The oldest blog post is from 2007.
       expect(posts.last[:created_at].year).to be(2007)
 
-      expect(posts.first[:created_at].to_i).to be > posts[1][:created_at].to_i
-      expect(posts.first[:created_at].to_i).to be > posts[posts.length - 1][:created_at].to_i
+      expect(posts.first[:created_at].to_i).to be >= posts[1][:created_at].to_i
+      expect(posts.first[:created_at].to_i).to be >= posts[posts.length - 1][:created_at].to_i
 
       expect(posts.length).to eq(@total_blog_posts)
     end
@@ -43,8 +43,8 @@ describe 'Blog Middleman Helper', :type => :helper do
       # The newest blog post is probably always this or the previous year…probably.
       expect(posts.last[:created_at].year).to be >= Time.now.year - 1
 
-      expect(posts.first[:created_at].to_i).to be < posts[1][:created_at].to_i
-      expect(posts.first[:created_at].to_i).to be < posts[posts.length - 1][:created_at].to_i
+      expect(posts.first[:created_at].to_i).to be <= posts[1][:created_at].to_i
+      expect(posts.first[:created_at].to_i).to be <= posts[posts.length - 1][:created_at].to_i
 
       expect(posts.length).to eq(@total_blog_posts)
     end


### PR DESCRIPTION
I don't think this needs a story.

---

We got a CI failure on this that was unexpected, maybe this `created_at` is a date and not a datetime, so if someone creates two blogs on the same day, this happens?

See: https://github.com/sharesight/www.sharesight.com/runs/2523000707?check_suite_focus=true

```sh
  1) Blog Middleman Helper blog_posts can be ordered by :latest_first
     Failure/Error: expect(posts.first[:created_at].to_i).to be > posts[1][:created_at].to_i
       expected: > 1620259200
            got:   1620259200
```