### PR TITLE
Add url slug and remove Wordpress Url

### DIFF
--- a/helpers/blog_helper.rb
+++ b/helpers/blog_helper.rb
@@ -3,6 +3,8 @@ module BlogHelper
   # Try to switch over to super.url_slug, if possible!
   def self.url_slug(post)
     # This is Split out for Testing Purposes.
+    return post.url_slug if post&.url_slug&.present?
+
     return url_slug_from_wordpress_url(post&.wordpress_url) if post&.wordpress_url&.present?
     return url_slug_from_title(post&.title)
   end

--- a/helpers/blog_helper.rb
+++ b/helpers/blog_helper.rb
@@ -4,14 +4,7 @@ module BlogHelper
   def self.url_slug(post)
     # This is Split out for Testing Purposes.
     return post.url_slug if post&.url_slug&.present?
-
-    return url_slug_from_wordpress_url(post&.wordpress_url) if post&.wordpress_url&.present?
     return url_slug_from_title(post&.title)
-  end
-
-  def self.url_slug_from_wordpress_url(wordpress_url)
-    # Use wordpress urls for SEO purposes.
-    return wordpress_url&.strip.split('/')[-1]
   end
 
   def self.url_slug_from_title(title)

--- a/mappers/blog/post.rb
+++ b/mappers/blog/post.rb
@@ -8,15 +8,19 @@ class BlogPostMapper < ContentfulMiddleman::Mapper::Base
       context.slug = context.title&.downcase.urlize.squeeze('-') # Adds url slugs if they don't exist.
     end
 
-    context.title = context.title&.to_s.squeeze(' ').strip # An author enters ' Great   Title!' and it becomes 'Great Title!'
+    if keys.include?(:title)
+      context.title = context.title&.to_s.squeeze(' ').strip # An author enters ' Great   Title!' and it becomes 'Great Title!'
+    end
 
-    # some sanitizing of blog content
-    context.content = (context.content || '')
-      .gsub('.png)', '.png?w=950)') # restrict image width
-      .gsub('.jpg)', '.jpg?w=950)')
-      .gsub('//images.contentful.com/', '//images.ctfassets.net/') # redirect old assets
-      .gsub('//assets.contentful.com/', '//assets.ctfassets.net/') # see: https://www.contentful.com/blog/2017/12/08/change-of-the-contentful-asset-domain/
-      .gsub('//downloads.contentful.com/', '//downloads.ctfassets.net/')
-      .gsub('//videos.contentful.com/', '//videos.ctfassets.net/')
+    if keys.include?(:content)
+      # some sanitizing of blog content
+      context.content = (context.content || '')
+        .gsub('.png)', '.png?w=950)') # restrict image width
+        .gsub('.jpg)', '.jpg?w=950)')
+        .gsub('//images.contentful.com/', '//images.ctfassets.net/') # redirect old assets
+        .gsub('//assets.contentful.com/', '//assets.ctfassets.net/') # see: https://www.contentful.com/blog/2017/12/08/change-of-the-contentful-asset-domain/
+        .gsub('//downloads.contentful.com/', '//downloads.ctfassets.net/')
+        .gsub('//videos.contentful.com/', '//videos.ctfassets.net/')
+    end
   end
 end

--- a/migrations/transformWordpressToUrlSlug.js
+++ b/migrations/transformWordpressToUrlSlug.js
@@ -1,0 +1,29 @@
+// Copy the wordpress URL field into the urlSlug field for all blog posts
+// that have a wordpress URL set, and no Url Slug set.
+// Should be run with the contentful migration tool: https://github.com/contentful/contentful-migration
+
+module.exports = function (migration) {
+  migration.transformEntries({
+    contentType: 'post',
+    from: ['wordpress_url', 'urlSlug'],
+    to: ['urlSlug'],
+    transformEntryForLocale: function (fromFields, currentLocale) {
+      const wordPressUrl = fromFields.wordpressUrl;
+      if (wordPressUrl == null || wordPressUrl == undefined || wordPressUrl == "") {
+        console.log("No wordpress url; nothing to do");
+        return;
+      }
+
+      const urlSlug = fromFields.urlSlug;
+      if (urlSlug != null) {
+        console.log("Refusing to update existing slug");
+        return;
+      }
+
+      const wordPressUrlValue = wordPressUrl[currentLocale].toString();
+      const newSlug = wordPressUrlValue.match(/\/\/([\S]+)/)[1];
+      console.log(`Migrating to new slug: ${newSlug} from: ${wordPressUrlValue}`)
+      return { urlSlug: newSlug};
+    }
+  });
+};

--- a/spec/helpers/blog_helper_spec.rb
+++ b/spec/helpers/blog_helper_spec.rb
@@ -28,8 +28,20 @@ describe 'Blog Helper', :type => :helper do
       end
     end
 
-    it "should return the correct url when a wordpress_url is provided" do
-      @posts.select{ |post| post.wordpress_url&.present? }.each do |post|
+    it 'should return the correct url when a url slug is provided' do
+      @posts.select { |post| post.url_slug.present? }.each do |post|
+        expect(BlogHelper::url_slug(post)).to eq(post.url_slug)
+      end
+    end
+
+    it 'should use the prioritise using the url slug over the wordpress url' do
+      @posts.select { |post| post.url_slug.present? && post.wordpress_url&.present? }.each do |post|
+        expect(BlogHelper::url_slug(post)).to eq(post.url_slug)
+      end
+    end
+
+    it "should return the correct url when a wordpress_url is provided and no url slug" do
+      @posts.select{ |post| post.wordpress_url&.present? && !post.url_slug&.present?}.each do |post|
         expect(BlogHelper::url_slug(post)).to eq(BlogHelper::url_slug_from_wordpress_url(post[:wordpress_url]))
       end
     end

--- a/spec/helpers/blog_helper_spec.rb
+++ b/spec/helpers/blog_helper_spec.rb
@@ -29,7 +29,10 @@ describe 'Blog Helper', :type => :helper do
     end
 
     it 'should return the correct url when a url slug is provided' do
-      @posts.select { |post| post.url_slug.present? }.each do |post|
+      url_slug_posts = @posts.select { |post| post.url_slug.present? }
+
+      expect(url_slug_posts.length).to be >= 1
+      url_slug_posts.each do |post|
         expect(BlogHelper::url_slug(post)).to eq(post.url_slug)
       end
     end

--- a/spec/helpers/blog_helper_spec.rb
+++ b/spec/helpers/blog_helper_spec.rb
@@ -13,7 +13,7 @@ describe 'Blog Helper', :type => :helper do
         ['2017', ' 2017 '],
         ['foo--bar', ' foo --  bar']
       ].each do |arr|
-        fake_post = OpenStruct.new(title: arr[1], wordpress_url: '')
+        fake_post = OpenStruct.new(title: arr[1])
         expect(arr[0]).to eq(BlogHelper::url_slug(fake_post))
       end
 
@@ -23,7 +23,7 @@ describe 'Blog Helper', :type => :helper do
         ['2017 ', ' 2017 '],
         ['foo-bar', ' foo --  bar']
       ].each do |arr|
-        fake_post = OpenStruct.new(title: arr[1], wordpress_url: '')
+        fake_post = OpenStruct.new(title: arr[1])
         expect(arr[0]).not_to eq(BlogHelper::url_slug(fake_post))
       end
     end
@@ -34,20 +34,8 @@ describe 'Blog Helper', :type => :helper do
       end
     end
 
-    it 'should use the prioritise using the url slug over the wordpress url' do
-      @posts.select { |post| post.url_slug.present? && post.wordpress_url&.present? }.each do |post|
-        expect(BlogHelper::url_slug(post)).to eq(post.url_slug)
-      end
-    end
-
-    it "should return the correct url when a wordpress_url is provided and no url slug" do
-      @posts.select{ |post| post.wordpress_url&.present? && !post.url_slug&.present?}.each do |post|
-        expect(BlogHelper::url_slug(post)).to eq(BlogHelper::url_slug_from_wordpress_url(post[:wordpress_url]))
-      end
-    end
-
-    it "should return the correct url when a wordpress_url is not provided" do
-      @posts.select{ |post| !post.wordpress_url&.present? }.each do |post|
+    it "should return the correct url when a url_slug is not provided" do
+      @posts.select{ |post| !post.url_slug&.present? }.each do |post|
         expect(BlogHelper::url_slug(post)).to eq(BlogHelper::url_slug_from_title(post[:title]))
       end
     end
@@ -57,7 +45,7 @@ describe 'Blog Helper', :type => :helper do
     it "should be valid" do
       [
         OpenStruct.new({ title: 'title', author: { name: 'name' }, featured_image: { url: 'url' } }),
-        OpenStruct.new({ title: 'title', author: { name: 'name' }, featured_image: { url: 'url' }, wordpress_url: 'foo-bar' }),
+        OpenStruct.new({ title: 'title', author: { name: 'name' }, featured_image: { url: 'url' } }),
       ].each do |obj|
         expect(BlogHelper.is_valid_post?(obj)).to be(true)
       end
@@ -65,7 +53,7 @@ describe 'Blog Helper', :type => :helper do
 
     it "should be invalid" do
       [
-        OpenStruct.new({ title: ' ', author: { name: 'name' }, featured_image: { url: 'url' }, wordpress_url: 'foo-bar' }),
+        OpenStruct.new({ title: ' ', author: { name: 'name' }, featured_image: { url: 'url' } }),
         OpenStruct.new({ id: '123' }),
         OpenStruct.new({ title: 'title', author: {}, featured_image: {} }),
         OpenStruct.new({ title: 'title', author: {}, featured_image: {} }),


### PR DESCRIPTION
[ticket](https://vimaly.com/#j8mqm/t/www_seo_Allow_renaming_of_a_blog_title_without_cha.../9IKh1BKLxSk3QmU73)

Adds url_slug to blog posts, which if set will be used as the URL. This is now a required field, so new and edited blog posts will all have a url slug set. Older ones will still use the title, which removes the need for a migration.

This also removes wordpress url from the codebase. When this is deployed, we can remove the word press url content type. I've added a migration here that showed there are no articles with wordpress url set; we can remove this migration from the code, I just left it here to give an example if we need to do any in the future.