### PR TITLE
Fix our migration from wordpress URL to url_slug

### DIFF
--- a/migrations/transformWordpressToUrlSlug.js
+++ b/migrations/transformWordpressToUrlSlug.js
@@ -8,7 +8,7 @@ module.exports = function (migration) {
     from: ['wordpress_url', 'urlSlug'],
     to: ['urlSlug'],
     transformEntryForLocale: function (fromFields, currentLocale) {
-      const wordPressUrl = fromFields.wordpressUrl;
+      const wordPressUrl = fromFields.wordpress_url;
       if (wordPressUrl == null || wordPressUrl == undefined || wordPressUrl == "") {
         console.log("No wordpress url; nothing to do");
         return;
@@ -21,7 +21,11 @@ module.exports = function (migration) {
       }
 
       const wordPressUrlValue = wordPressUrl[currentLocale].toString();
-      const newSlug = wordPressUrlValue.match(/\/\/([\S]+)/)[1];
+      console.log("WordPressURL: " + wordPressUrlValue);
+
+      const urlArray = wordPressUrlValue.split("/");
+      const newSlug = urlArray[urlArray.length - 2]; // there is a trailing '/' on wordpress URL
+
       console.log(`Migrating to new slug: ${newSlug} from: ${wordPressUrlValue}`)
       return { urlSlug: newSlug};
     }


### PR DESCRIPTION
Use the correct variable name for `wordpress_url` so our migration to `url_slug` actually works correctly.

[ticket](https://vimaly.com/#j8mqm/t/Marketing_Site_Wordpress_URL_deleted_incorrectly/Y5b7nmKm9EGnE8Z6w)

Output from migration on `dev`: 

```
WordPressURL: /2014/09/09/new-feature-charting-improvements/
Migrating to new slug: new-feature-charting-improvements from: /2014/09/09/new-feature-charting-improvements/
WordPressURL: /2015/06/24/vivid-sydney-collaboration-fintech-sunrise/
Migrating to new slug: vivid-sydney-collaboration-fintech-sunrise from: /2015/06/24/vivid-sydney-collaboration-fintech-sunrise/
WordPressURL: /2013/11/05/greetings-from-sydney/
Migrating to new slug: greetings-from-sydney from: /2013/11/05/greetings-from-sydney/
WordPressURL: /2015/05/01/innovate-with-caution-why-start-ups-should-be-wary-of-bank-led-fintech-hubs/
Migrating to new slug: innovate-with-caution-why-start-ups-should-be-wary-of-bank-led-fintech-hubs from: /2015/05/01/innovate-with-caution-why-start-ups-should-be-wary-of-bank-led-fintech-hubs/
WordPressURL: /2011/12/05/sharesight-now-your-free-online-portfolio-manager/
Migrating to new slug: sharesight-now-your-free-online-portfolio-manager from: /2011/12/05/sharesight-now-your-free-online-portfolio-manager/
WordPressURL: /2013/06/18/tips-for-becoming-a-successful-share-market-investor-tip-6/
Migrating to new slug: tips-for-becoming-a-successful-share-market-investor-tip-6 from: /2013/06/18/tips-for-becoming-a-successful-share-market-investor-tip-6/
WordPressURL: /2015/02/18/day-yarra-vanguard/
Migrating to new slug: day-yarra-vanguard from: /2015/02/18/day-yarra-vanguard/
WordPressURL: /2011/12/08/maintaining-your-portfolio-just-got-a-whole-lot-easier/
Migrating to new slug: maintaining-your-portfolio-just-got-a-whole-lot-easier from: /2011/12/08/maintaining-your-portfolio-just-got-a-whole-lot-easier/
WordPressURL: /2015/04/20/subscribe-to-our-updates/
Migrating to new slug: subscribe-to-our-updates from: /2015/04/20/subscribe-to-our-updates/
WordPressURL: /2014/02/14/managed-funds-live-on-sharesight/
Migrating to new slug: managed-funds-live-on-sharesight from: /2014/02/14/managed-funds-live-on-sharesight/
WordPressURL: /2008/03/25/sharesight-the-custodial-system-you-have-when-you-don%e2%80%99t-have-a-custodial-system/
Migrating to new slug: sharesight-the-custodial-system-you-have-when-you-don%e2%80%99t-have-a-custodial-system from: /2008/03/25/sharesight-the-custodial-system-you-have-when-you-don%e2%80%99t-have-a-custodial-system/
WordPressURL: /2014/08/14/6-sleeps-until-xerocon/
Migrating to new slug: 6-sleeps-until-xerocon from: /2014/08/14/6-sleeps-until-xerocon/
WordPressURL: /2015/08/26/introducing-emma-our-new-customer-support-guru/
Migrating to new slug: introducing-emma-our-new-customer-support-guru from: /2015/08/26/introducing-emma-our-new-customer-support-guru/
WordPressURL: /2012/04/20/evolving-the-client-accountant-relationship/
Migrating to new slug: evolving-the-client-accountant-relationship from: /2012/04/20/evolving-the-client-accountant-relationship/
WordPressURL: /2009/08/11/sharesight-and-xero/
Migrating to new slug: sharesight-and-xero from: /2009/08/11/sharesight-and-xero/
WordPressURL: /2014/08/18/why-share-registries-arent-enough/
Migrating to new slug: why-share-registries-arent-enough from: /2014/08/18/why-share-registries-arent-enough/
WordPressURL: /2014/07/11/why-do-i-need-sharesight-with-my-online-broker/
Migrating to new slug: why-do-i-need-sharesight-with-my-online-broker from: /2014/07/11/why-do-i-need-sharesight-with-my-online-broker/
WordPressURL: /2011/08/10/importing-your-portfolio-just-got-easier/
Migrating to new slug: importing-your-portfolio-just-got-easier from: /2011/08/10/importing-your-portfolio-just-got-easier/
WordPressURL: /2012/02/09/sharing-between-generations/
Migrating to new slug: sharing-between-generations from: /2012/02/09/sharing-between-generations/
WordPressURL: /2015/01/12/the-sharesight-story/
Migrating to new slug: the-sharesight-story from: /2015/01/12/the-sharesight-story/
WordPressURL: /2008/02/25/aussies-are-richer-than-us-but-are-they-smarter/
Migrating to new slug: aussies-are-richer-than-us-but-are-they-smarter from: /2008/02/25/aussies-are-richer-than-us-but-are-they-smarter/
WordPressURL: /2015/08/05/bank-fees-vs-it-spend-and-the-essence-of-fintech/
Migrating to new slug: bank-fees-vs-it-spend-and-the-essence-of-fintech from: /2015/08/05/bank-fees-vs-it-spend-and-the-essence-of-fintech/
WordPressURL: /2015/01/14/a-tale-of-three-aussie-funds/
Migrating to new slug: a-tale-of-three-aussie-funds from: /2015/01/14/a-tale-of-three-aussie-funds/
WordPressURL: /2013/11/18/sharesights-beautiful-xero-integration/
Migrating to new slug: sharesights-beautiful-xero-integration from: /2013/11/18/sharesights-beautiful-xero-integration/
WordPressURL: /2012/01/31/efficiency-measures-how-to-boost-portfolio-share-performance-without-relying-on-the-market/
Migrating to new slug: efficiency-measures-how-to-boost-portfolio-share-performance-without-relying-on-the-market from: /2012/01/31/efficiency-measures-how-to-boost-portfolio-share-performance-without-relying-on-the-market/
WordPressURL: /2008/10/28/have-the-doomsayers-got-it-wrong/
Migrating to new slug: have-the-doomsayers-got-it-wrong from: /2008/10/28/have-the-doomsayers-got-it-wrong/
WordPressURL: /2014/10/22/dont-wait-until-markets-tumble-to-track-your-investments/
Migrating to new slug: dont-wait-until-markets-tumble-to-track-your-investments from: /2014/10/22/dont-wait-until-markets-tumble-to-track-your-investments/
WordPressURL: /2007/12/19/asx-historic-data-now-in-sharesight/
Migrating to new slug: asx-historic-data-now-in-sharesight from: /2007/12/19/asx-historic-data-now-in-sharesight/
WordPressURL: /2015/11/16/what-we-learned-when-recruiting-for-our-fintech/
Migrating to new slug: what-we-learned-when-recruiting-for-our-fintech from: /2015/11/16/what-we-learned-when-recruiting-for-our-fintech/
WordPressURL: /2010/10/22/upcoming-events/
Migrating to new slug: upcoming-events from: /2010/10/22/upcoming-events/
WordPressURL: /2011/12/23/two-brokers-can-be-better-than-one/
Migrating to new slug: two-brokers-can-be-better-than-one from: /2011/12/23/two-brokers-can-be-better-than-one/
WordPressURL: /2011/02/23/diversity-reporting-now-available/
Migrating to new slug: diversity-reporting-now-available from: /2011/02/23/diversity-reporting-now-available/
WordPressURL: /2008/10/07/whos-to-blame-for-the-financial-meltdown/
Migrating to new slug: whos-to-blame-for-the-financial-meltdown from: /2008/10/07/whos-to-blame-for-the-financial-meltdown/
WordPressURL: /2015/04/15/were-hiring-a-sales-engineer/
Migrating to new slug: were-hiring-a-sales-engineer from: /2015/04/15/were-hiring-a-sales-engineer/
WordPressURL: /2014/04/11/how-do-i-run-capital-gains-tax-reports-in-sharesight/
Migrating to new slug: how-do-i-run-capital-gains-tax-reports-in-sharesight from: /2014/04/11/how-do-i-run-capital-gains-tax-reports-in-sharesight/
WordPressURL: /2014/03/27/sharesight-xero-financial-advisers/
Migrating to new slug: sharesight-xero-financial-advisers from: /2014/03/27/sharesight-xero-financial-advisers/
WordPressURL: /2015/06/29/sharesight-goes-global/
Migrating to new slug: sharesight-goes-global from: /2015/06/29/sharesight-goes-global/
WordPressURL: /2015/11/05/sharesight-named-cuffelinks-alliance-partner/
Migrating to new slug: sharesight-named-cuffelinks-alliance-partner from: /2015/11/05/sharesight-named-cuffelinks-alliance-partner/
WordPressURL: /2015/06/16/global-stock-markets/
Migrating to new slug: global-stock-markets from: /2015/06/16/global-stock-markets/
WordPressURL: /2014/10/02/asx-mfund-now-available-on-sharesight/
Migrating to new slug: asx-mfund-now-available-on-sharesight from: /2014/10/02/asx-mfund-now-available-on-sharesight/
WordPressURL: /2015/09/25/manage-your-income-properties-with-real-estate-investar/
Migrating to new slug: manage-your-income-properties-with-real-estate-investar from: /2015/09/25/manage-your-income-properties-with-real-estate-investar/
WordPressURL: /2014/09/11/customers-say/
Migrating to new slug: customers-say from: /2014/09/11/customers-say/
WordPressURL: /2014/10/15/what-is-automation-worth-to-you/
Migrating to new slug: what-is-automation-worth-to-you from: /2014/10/15/what-is-automation-worth-to-you/
WordPressURL: /2015/05/28/sharesight-ceo-cto/
Migrating to new slug: sharesight-ceo-cto from: /2015/05/28/sharesight-ceo-cto/
WordPressURL: /2010/03/16/rewardsuper-and-sharesight/
Migrating to new slug: rewardsuper-and-sharesight from: /2010/03/16/rewardsuper-and-sharesight/
WordPressURL: /2015/03/27/see-xerocon-auckland/
Migrating to new slug: see-xerocon-auckland from: /2015/03/27/see-xerocon-auckland/
WordPressURL: /2009/07/28/the-2025-taskforce/
Migrating to new slug: the-2025-taskforce from: /2009/07/28/the-2025-taskforce/
WordPressURL: /2011/10/17/how-does-sharesight-operate-in-the-cloud/
Migrating to new slug: how-does-sharesight-operate-in-the-cloud from: /2011/10/17/how-does-sharesight-operate-in-the-cloud/
WordPressURL: /2016/06/17/how-to-calculate-your-2016-fif-income/
Migrating to new slug: how-to-calculate-your-2016-fif-income from: /2016/06/17/how-to-calculate-your-2016-fif-income/
WordPressURL: /2015/10/09/auto-track-your-suncorp-trades/
Migrating to new slug: auto-track-your-suncorp-trades from: /2015/10/09/auto-track-your-suncorp-trades/
WordPressURL: /2015/09/28/afiniation-showcase-wrap/
Migrating to new slug: afiniation-showcase-wrap from: /2015/09/28/afiniation-showcase-wrap/
WordPressURL: /2013/06/26/what-is-a-portfolio-manager-part-one/
Migrating to new slug: what-is-a-portfolio-manager-part-one from: /2013/06/26/what-is-a-portfolio-manager-part-one/
WordPressURL: /2015/08/25/how-smart-advisers-are-leveraging-disruption/
Migrating to new slug: how-smart-advisers-are-leveraging-disruption from: /2015/08/25/how-smart-advisers-are-leveraging-disruption/
WordPressURL: /2013/09/10/handling-cash-investments-with-sharesight/
Migrating to new slug: handling-cash-investments-with-sharesight from: /2013/09/10/handling-cash-investments-with-sharesight/
WordPressURL: /2015/04/22/sharesight-xero-for-smsfs/
Migrating to new slug: sharesight-xero-for-smsfs from: /2015/04/22/sharesight-xero-for-smsfs/
WordPressURL: /2013/07/09/tips-for-becoming-a-successful-share-market-investor-tip-9/
Migrating to new slug: tips-for-becoming-a-successful-share-market-investor-tip-9 from: /2013/07/09/tips-for-becoming-a-successful-share-market-investor-tip-9/
WordPressURL: /2016/04/27/macquarie-sydney-airport-reconstruction/
Migrating to new slug: macquarie-sydney-airport-reconstruction from: /2016/04/27/macquarie-sydney-airport-reconstruction/
WordPressURL: /2013/10/24/greetings-from-melbourne/
Migrating to new slug: greetings-from-melbourne from: /2013/10/24/greetings-from-melbourne/
WordPressURL: /2016/02/29/livewire-market-insights-within-your-portfolio/
Migrating to new slug: livewire-market-insights-within-your-portfolio from: /2016/02/29/livewire-market-insights-within-your-portfolio/
WordPressURL: /2016/05/27/asset-allocation-reporting-in-sharesight/
Migrating to new slug: asset-allocation-reporting-in-sharesight from: /2016/05/27/asset-allocation-reporting-in-sharesight/
WordPressURL: /2015/09/03/investment-insights-from-livewire/
Migrating to new slug: investment-insights-from-livewire from: /2015/09/03/investment-insights-from-livewire/
WordPressURL: /2009/04/17/back-to-the-future-have-we-got-too-smart-for-our-own-good/
Migrating to new slug: back-to-the-future-have-we-got-too-smart-for-our-own-good from: /2009/04/17/back-to-the-future-have-we-got-too-smart-for-our-own-good/
WordPressURL: /2016/05/30/how-i-manage-my-smsf-with-sharesight/
Migrating to new slug: how-i-manage-my-smsf-with-sharesight from: /2016/05/30/how-i-manage-my-smsf-with-sharesight/
WordPressURL: /2008/11/14/god-bless-america/
Migrating to new slug: god-bless-america from: /2008/11/14/god-bless-america/
WordPressURL: /2016/04/18/how-to-track-a-dividend-reinvestment-plan/
Migrating to new slug: how-to-track-a-dividend-reinvestment-plan from: /2016/04/18/how-to-track-a-dividend-reinvestment-plan/
WordPressURL: /2010/06/08/a-good-tax-budget-but-a-pity-about-fif/
Migrating to new slug: a-good-tax-budget-but-a-pity-about-fif from: /2010/06/08/a-good-tax-budget-but-a-pity-about-fif/
WordPressURL: /2014/01/13/scrap-those-new-years-resolutions-and-get-real-portfolio-setup-tip-1-opening-balances-manual-entry-are-your-best-friend/
Migrating to new slug: scrap-those-new-years-resolutions-and-get-real-portfolio-setup-tip-1-opening-balances-manual-entry-are-your-best-friend from: /2014/01/13/scrap-those-new-years-resolutions-and-get-real-portfolio-setup-tip-1-opening-balances-manual-entry-are-your-best-friend/
WordPressURL: /2013/05/14/tips-for-becoming-a-successful-share-market-investor-tip-1/
Migrating to new slug: tips-for-becoming-a-successful-share-market-investor-tip-1 from: /2013/05/14/tips-for-becoming-a-successful-share-market-investor-tip-1/
WordPressURL: /2014/06/18/5-ways-sharesight-makes-eofy-a-breeze/
Migrating to new slug: 5-ways-sharesight-makes-eofy-a-breeze from: /2014/06/18/5-ways-sharesight-makes-eofy-a-breeze/
WordPressURL: /2014/12/02/awi-asx-fintech-expo-roundup/
Migrating to new slug: awi-asx-fintech-expo-roundup from: /2014/12/02/awi-asx-fintech-expo-roundup/
WordPressURL: /2014/11/21/how-do-i-attach-a-file-in-sharesight/
Migrating to new slug: how-do-i-attach-a-file-in-sharesight from: /2014/11/21/how-do-i-attach-a-file-in-sharesight/
WordPressURL: /2014/06/12/why-does-finance-hate-technology/
Migrating to new slug: why-does-finance-hate-technology from: /2014/06/12/why-does-finance-hate-technology/
WordPressURL: /2010/09/22/sharesight-and-direct-broking/
Migrating to new slug: sharesight-and-direct-broking from: /2010/09/22/sharesight-and-direct-broking/
WordPressURL: /2015/09/09/join-us-afiniation-showcase/
Migrating to new slug: join-us-afiniation-showcase from: /2015/09/09/join-us-afiniation-showcase/
WordPressURL: /2008/06/16/fif-report-now-available/
Migrating to new slug: fif-report-now-available from: /2008/06/16/fif-report-now-available/
WordPressURL: /2008/01/18/rough-week/
Migrating to new slug: rough-week from: /2008/01/18/rough-week/
WordPressURL: /2015/07/08/announcing-sharesight-canada/
Migrating to new slug: announcing-sharesight-canada from: /2015/07/08/announcing-sharesight-canada/
WordPressURL: /2013/09/03/tips-for-becoming-a-successful-share-market-investor-tip-17/
Migrating to new slug: tips-for-becoming-a-successful-share-market-investor-tip-17 from: /2013/09/03/tips-for-becoming-a-successful-share-market-investor-tip-17/
WordPressURL: /2014/09/25/is-zero-dollar-brokerage-too-good-to-be-true/
Migrating to new slug: is-zero-dollar-brokerage-too-good-to-be-true from: /2014/09/25/is-zero-dollar-brokerage-too-good-to-be-true/
WordPressURL: /2014/09/05/sports-media-platform/
Migrating to new slug: sports-media-platform from: /2014/09/05/sports-media-platform/
WordPressURL: /2014/08/13/track-cash-fixed-interest-investments-via-xero/
Migrating to new slug: track-cash-fixed-interest-investments-via-xero from: /2014/08/13/track-cash-fixed-interest-investments-via-xero/
WordPressURL: /2013/05/03/dividend-franking-and-performance/
Migrating to new slug: dividend-franking-and-performance from: /2013/05/03/dividend-franking-and-performance/
WordPressURL: /2011/08/18/we-don%e2%80%99t-know-how-lucky-we-are/
Migrating to new slug: we-don%e2%80%99t-know-how-lucky-we-are from: /2011/08/18/we-don%e2%80%99t-know-how-lucky-we-are/
WordPressURL: /2015/07/02/calculate-fif-income/
Migrating to new slug: calculate-fif-income from: /2015/07/02/calculate-fif-income/
WordPressURL: /2014/02/25/xerocon-auckland-2014-from-sheep-to-shares/
Migrating to new slug: xerocon-auckland-2014-from-sheep-to-shares from: /2014/02/25/xerocon-auckland-2014-from-sheep-to-shares/
WordPressURL: /2014/06/04/what-apps-do-we-use-to-run-our-small-business/
Migrating to new slug: what-apps-do-we-use-to-run-our-small-business from: /2014/06/04/what-apps-do-we-use-to-run-our-small-business/
WordPressURL: /2014/11/19/login-to-sharesight-with-google/
Migrating to new slug: login-to-sharesight-with-google from: /2014/11/19/login-to-sharesight-with-google/
WordPressURL: /2014/05/06/investing-getting-cheaper/
Migrating to new slug: investing-getting-cheaper from: /2014/05/06/investing-getting-cheaper/
WordPressURL: /2015/01/16/join-us-xero-roadshow-february-2015/
Migrating to new slug: join-us-xero-roadshow-february-2015 from: /2015/01/16/join-us-xero-roadshow-february-2015/
WordPressURL: /2013/05/21/tips-for-becoming-a-successful-share-market-investor-tip-2/
Migrating to new slug: tips-for-becoming-a-successful-share-market-investor-tip-2 from: /2013/05/21/tips-for-becoming-a-successful-share-market-investor-tip-2/
WordPressURL: /2015/07/07/merge-custom-holdings-to-listed-securities/
Migrating to new slug: merge-custom-holdings-to-listed-securities from: /2015/07/07/merge-custom-holdings-to-listed-securities/
WordPressURL: /2016/06/10/sharesight-bank-of-queensland/
Migrating to new slug: sharesight-bank-of-queensland from: /2016/06/10/sharesight-bank-of-queensland/
WordPressURL: /2014/03/24/sharesight-adds-marketing-focus/
Migrating to new slug: sharesight-adds-marketing-focus from: /2014/03/24/sharesight-adds-marketing-focus/
WordPressURL: /2008/01/28/should-i-sell-my-shares/
Migrating to new slug: should-i-sell-my-shares from: /2008/01/28/should-i-sell-my-shares/
WordPressURL: /2013/07/30/how-not-to-handle-a-share-market-downturn/
Migrating to new slug: how-not-to-handle-a-share-market-downturn from: /2013/07/30/how-not-to-handle-a-share-market-downturn/
WordPressURL: /2011/09/14/we-have-had-another-share-market-collapse-so-what/
Migrating to new slug: we-have-had-another-share-market-collapse-so-what from: /2011/09/14/we-have-had-another-share-market-collapse-so-what/
WordPressURL: /2008/07/08/performance-report/
Migrating to new slug: performance-report from: /2008/07/08/performance-report/
WordPressURL: /2008/08/13/australia%e2%80%99s-secret-economic-weapon/
Migrating to new slug: australia%e2%80%99s-secret-economic-weapon from: /2008/08/13/australia%e2%80%99s-secret-economic-weapon/
WordPressURL: /2016/05/11/sharesight-chrome-extension/
Migrating to new slug: sharesight-chrome-extension from: /2016/05/11/sharesight-chrome-extension/
WordPressURL: /2015/04/01/announcing-partnership-intelligent-investor/
Migrating to new slug: announcing-partnership-intelligent-investor from: /2015/04/01/announcing-partnership-intelligent-investor/
WordPressURL: /2011/06/01/sharesight-appoints-andrew-bird-as-australian-executive-director/
Migrating to new slug: sharesight-appoints-andrew-bird-as-australian-executive-director from: /2011/06/01/sharesight-appoints-andrew-bird-as-australian-executive-director/
WordPressURL: /2007/10/01/first-post/
Migrating to new slug: first-post from: /2007/10/01/first-post/
WordPressURL: /2008/01/07/watch-your-investment-grow/
Migrating to new slug: watch-your-investment-grow from: /2008/01/07/watch-your-investment-grow/
WordPressURL: /2013/04/09/will-mighty-rivers-share-price-sink-or-swim/
Migrating to new slug: will-mighty-rivers-share-price-sink-or-swim from: /2013/04/09/will-mighty-rivers-share-price-sink-or-swim/
WordPressURL: /2014/09/16/hear-xero-award-winners/
Migrating to new slug: hear-xero-award-winners from: /2014/09/16/hear-xero-award-winners/
WordPressURL: /2013/05/16/share-records-you-must-keep-to-complete-your-tax-return/
Migrating to new slug: share-records-you-must-keep-to-complete-your-tax-return from: /2013/05/16/share-records-you-must-keep-to-complete-your-tax-return/
WordPressURL: /2015/05/15/can-specialist-products-survive/
Migrating to new slug: can-specialist-products-survive from: /2015/05/15/can-specialist-products-survive/
WordPressURL: /2015/04/23/thoughts-senate-inquiry/
Migrating to new slug: thoughts-senate-inquiry from: /2015/04/23/thoughts-senate-inquiry/
WordPressURL: /2013/07/23/tips-for-becoming-a-successful-share-market-investor-tip-11/
Migrating to new slug: tips-for-becoming-a-successful-share-market-investor-tip-11 from: /2013/07/23/tips-for-becoming-a-successful-share-market-investor-tip-11/
WordPressURL: /2013/07/03/what-is-a-portfolio-manager-part-two/
Migrating to new slug: what-is-a-portfolio-manager-part-two from: /2013/07/03/what-is-a-portfolio-manager-part-two/
WordPressURL: /2008/04/09/calling-all-share-clubs/
Migrating to new slug: calling-all-share-clubs from: /2008/04/09/calling-all-share-clubs/
WordPressURL: /2009/07/20/nz-shareholders-association-agm/
Migrating to new slug: nz-shareholders-association-agm from: /2009/07/20/nz-shareholders-association-agm/
WordPressURL: /2010/03/15/my-summer-of-code/
Migrating to new slug: my-summer-of-code from: /2010/03/15/my-summer-of-code/
WordPressURL: /2016/06/03/eofy/
Migrating to new slug: eofy from: /2016/06/03/eofy/
WordPressURL: /2015/08/21/join-us-at-the-nz-xero-roadshow/
Migrating to new slug: join-us-at-the-nz-xero-roadshow from: /2015/08/21/join-us-at-the-nz-xero-roadshow/
WordPressURL: /2008/02/01/do-you-need-to-diversify-your-investments/
Migrating to new slug: do-you-need-to-diversify-your-investments from: /2008/02/01/do-you-need-to-diversify-your-investments/
WordPressURL: /2015/07/29/hiring/
Migrating to new slug: hiring from: /2015/07/29/hiring/
WordPressURL: /2008/05/23/how-much-will-you-get-from-the-2008-budget-tax-cuts/
Migrating to new slug: how-much-will-you-get-from-the-2008-budget-tax-cuts from: /2008/05/23/how-much-will-you-get-from-the-2008-budget-tax-cuts/
WordPressURL: /2013/10/30/greetings-from-perth/
Migrating to new slug: greetings-from-perth from: /2013/10/30/greetings-from-perth/
WordPressURL: /2008/05/16/how-to-get-the-most-out-of-20000/
Migrating to new slug: how-to-get-the-most-out-of-20000 from: /2008/05/16/how-to-get-the-most-out-of-20000/
WordPressURL: /2014/08/07/visit-sharesight-booth-xerocon-sydney-2014/
Migrating to new slug: visit-sharesight-booth-xerocon-sydney-2014 from: /2014/08/07/visit-sharesight-booth-xerocon-sydney-2014/
WordPressURL: /2008/11/02/what-does-the-economic-future-hold-for-nz-have-the-doomsayers-got-it-wrong-part-2/
Migrating to new slug: what-does-the-economic-future-hold-for-nz-have-the-doomsayers-got-it-wrong-part-2 from: /2008/11/02/what-does-the-economic-future-hold-for-nz-have-the-doomsayers-got-it-wrong-part-2/
WordPressURL: /2015/10/08/malcolm-turnbull-uttered-words-open-api/
Migrating to new slug: malcolm-turnbull-uttered-words-open-api from: /2015/10/08/malcolm-turnbull-uttered-words-open-api/
WordPressURL: /2008/12/15/who-needs-economists/
Migrating to new slug: who-needs-economists from: /2008/12/15/who-needs-economists/
WordPressURL: /2014/04/10/security-update-heartbleed-bug/
Migrating to new slug: security-update-heartbleed-bug from: /2014/04/10/security-update-heartbleed-bug/
WordPressURL: /2014/07/31/how-can-i-quickly-check-share-performance-and-dividends/
Migrating to new slug: how-can-i-quickly-check-share-performance-and-dividends from: /2014/07/31/how-can-i-quickly-check-share-performance-and-dividends/
WordPressURL: /2009/10/29/remember-me-function-improved/
Migrating to new slug: remember-me-function-improved from: /2009/10/29/remember-me-function-improved/
WordPressURL: /2016/05/26/nab-renounceable-rights-offer/
Migrating to new slug: nab-renounceable-rights-offer from: /2016/05/26/nab-renounceable-rights-offer/
WordPressURL: /2015/12/07/new-open-sharesight-reports-directly-google-sheets/
Migrating to new slug: new-open-sharesight-reports-directly-google-sheets from: /2015/12/07/new-open-sharesight-reports-directly-google-sheets/
WordPressURL: /2008/04/28/sold-shares-report/
Migrating to new slug: sold-shares-report from: /2008/04/28/sold-shares-report/
WordPressURL: /2014/09/18/xero-cashbooks-now-available-via-sharesight/
Migrating to new slug: xero-cashbooks-now-available-via-sharesight from: /2014/09/18/xero-cashbooks-now-available-via-sharesight/
WordPressURL: /2007/12/21/sharesight-sets-sail/
Migrating to new slug: sharesight-sets-sail from: /2007/12/21/sharesight-sets-sail/
WordPressURL: /2013/12/03/sharing-is-caring/
Migrating to new slug: sharing-is-caring from: /2013/12/03/sharing-is-caring/
WordPressURL: /2007/10/10/ui-enhancements/
Migrating to new slug: ui-enhancements from: /2007/10/10/ui-enhancements/
WordPressURL: /2012/03/29/offshore-investing-tips-to-get-you-started/
Migrating to new slug: offshore-investing-tips-to-get-you-started from: /2012/03/29/offshore-investing-tips-to-get-you-started/
WordPressURL: /2015/09/29/sharesight-wins-best-technology-award-at-afiniation/
Migrating to new slug: sharesight-wins-best-technology-award-at-afiniation from: /2015/09/29/sharesight-wins-best-technology-award-at-afiniation/
WordPressURL: /2011/11/23/why-accurate-performance-measurement-matters/
Migrating to new slug: why-accurate-performance-measurement-matters from: /2011/11/23/why-accurate-performance-measurement-matters/
WordPressURL: /2016/02/26/updated-industry-classification-data/
Migrating to new slug: updated-industry-classification-data from: /2016/02/26/updated-industry-classification-data/
WordPressURL: /2013/07/02/tips-for-becoming-a-successful-share-market-investor-tip-8/
Migrating to new slug: tips-for-becoming-a-successful-share-market-investor-tip-8 from: /2013/07/02/tips-for-becoming-a-successful-share-market-investor-tip-8/
WordPressURL: /2012/04/10/is-diy-investing-for-you/
Migrating to new slug: is-diy-investing-for-you from: /2012/04/10/is-diy-investing-for-you/
WordPressURL: /2015/05/13/introducing-multiple-contract-note-processing/
Migrating to new slug: introducing-multiple-contract-note-processing from: /2015/05/13/introducing-multiple-contract-note-processing/
WordPressURL: /2014/06/07/why-do-financial-advisers-use-sharesight/
Migrating to new slug: why-do-financial-advisers-use-sharesight from: /2014/06/07/why-do-financial-advisers-use-sharesight/
WordPressURL: /2007/12/01/we-wont-forget-you/
Migrating to new slug: we-wont-forget-you from: /2007/12/01/we-wont-forget-you/
WordPressURL: /2016/04/12/were-looking-for-marketing-superstars/
Migrating to new slug: were-looking-for-marketing-superstars from: /2016/04/12/were-looking-for-marketing-superstars/
WordPressURL: /2014/07/23/introducing-broker-import/
Migrating to new slug: introducing-broker-import from: /2014/07/23/introducing-broker-import/
WordPressURL: /2015/12/22/sharesight-raises-2-million-dollars/
Migrating to new slug: sharesight-raises-2-million-dollars from: /2015/12/22/sharesight-raises-2-million-dollars/
WordPressURL: /2015/10/28/track-the-swiss-tokyo-stock-exchanges/
Migrating to new slug: track-the-swiss-tokyo-stock-exchanges from: /2015/10/28/track-the-swiss-tokyo-stock-exchanges/
WordPressURL: /2015/05/08/xerocon-auckland-wrap-up/
Migrating to new slug: xerocon-auckland-wrap-up from: /2015/05/08/xerocon-auckland-wrap-up/
WordPressURL: /2007/10/22/painless-tax-returns/
Migrating to new slug: painless-tax-returns from: /2007/10/22/painless-tax-returns/
WordPressURL: /2013/06/04/tips-for-becoming-a-successful-share-market-investor-tip-4/
Migrating to new slug: tips-for-becoming-a-successful-share-market-investor-tip-4 from: /2013/06/04/tips-for-becoming-a-successful-share-market-investor-tip-4/
WordPressURL: /2013/04/17/data-entry-whats-that-have-your-share-trades-recorded-automatically/
Migrating to new slug: data-entry-whats-that-have-your-share-trades-recorded-automatically from: /2013/04/17/data-entry-whats-that-have-your-share-trades-recorded-automatically/
WordPressURL: /2011/08/24/sharesight-server-upgrade-outage-notice/
Migrating to new slug: sharesight-server-upgrade-outage-notice from: /2011/08/24/sharesight-server-upgrade-outage-notice/
WordPressURL: /2015/10/16/cmc-pro-platform-launch/
Migrating to new slug: cmc-pro-platform-launch from: /2015/10/16/cmc-pro-platform-launch/
WordPressURL: /2008/08/06/calculating-share-returns/
Migrating to new slug: calculating-share-returns from: /2008/08/06/calculating-share-returns/
WordPressURL: /2007/12/21/price-alerts-weekly-portfolio-performance-newsletter/
Migrating to new slug: price-alerts-weekly-portfolio-performance-newsletter from: /2007/12/21/price-alerts-weekly-portfolio-performance-newsletter/
WordPressURL: /2015/01/19/more-choice-for-investors-sharesight-featured-in-asx-newsletter/
Migrating to new slug: more-choice-for-investors-sharesight-featured-in-asx-newsletter from: /2015/01/19/more-choice-for-investors-sharesight-featured-in-asx-newsletter/
WordPressURL: /2011/11/09/portfolio-diversification-what-does-it-mean-to-you/
Migrating to new slug: portfolio-diversification-what-does-it-mean-to-you from: /2011/11/09/portfolio-diversification-what-does-it-mean-to-you/
WordPressURL: /2007/11/06/sales-acquisitions-report/
Migrating to new slug: sales-acquisitions-report from: /2007/11/06/sales-acquisitions-report/
WordPressURL: /2009/07/31/should-you-invest-in-bank-shares-or-bank-deposits/
Migrating to new slug: should-you-invest-in-bank-shares-or-bank-deposits from: /2009/07/31/should-you-invest-in-bank-shares-or-bank-deposits/
WordPressURL: /2016/03/30/sharesight-pro-portfolio-search-tool/
Migrating to new slug: sharesight-pro-portfolio-search-tool from: /2016/03/30/sharesight-pro-portfolio-search-tool/
WordPressURL: /2013/08/20/tips-for-becoming-a-successful-share-market-investor-tip-15/
Migrating to new slug: tips-for-becoming-a-successful-share-market-investor-tip-15 from: /2013/08/20/tips-for-becoming-a-successful-share-market-investor-tip-15/
WordPressURL: /2014/03/03/2-click-fif-reporting-yes-its-this-easy-yes-its-this-automatic/
Migrating to new slug: 2-click-fif-reporting-yes-its-this-easy-yes-its-this-automatic from: /2014/03/03/2-click-fif-reporting-yes-its-this-easy-yes-its-this-automatic/
WordPressURL: /2007/12/01/using-sharesight-is-now-easier-than-ever/
Migrating to new slug: using-sharesight-is-now-easier-than-ever from: /2007/12/01/using-sharesight-is-now-easier-than-ever/
WordPressURL: /2014/01/16/portfolio-setup-tip-2-opening-balances-bulk-upload-are-also-your-best-friend/
Migrating to new slug: portfolio-setup-tip-2-opening-balances-bulk-upload-are-also-your-best-friend from: /2014/01/16/portfolio-setup-tip-2-opening-balances-bulk-upload-are-also-your-best-friend/
WordPressURL: /2016/03/08/how-to-handle-the-nab-demerger-and-cyb-ipo/
Migrating to new slug: how-to-handle-the-nab-demerger-and-cyb-ipo from: /2016/03/08/how-to-handle-the-nab-demerger-and-cyb-ipo/
WordPressURL: /2016/06/06/livewire-live/
Migrating to new slug: livewire-live from: /2016/06/06/livewire-live/
WordPressURL: /2013/08/27/sharesight-at-xerocon-sydney-elevate-conference-28-30-august-2013/
Migrating to new slug: sharesight-at-xerocon-sydney-elevate-conference-28-30-august-2013 from: /2013/08/27/sharesight-at-xerocon-sydney-elevate-conference-28-30-august-2013/
WordPressURL: /2015/10/29/performance-tax-reports-now-xlsx-format/
Migrating to new slug: performance-tax-reports-now-xlsx-format from: /2015/10/29/performance-tax-reports-now-xlsx-format/
WordPressURL: /2015/06/18/mfund-from-asx-roadshow/
Migrating to new slug: mfund-from-asx-roadshow from: /2015/06/18/mfund-from-asx-roadshow/
WordPressURL: /2008/02/11/diversify-or-bust/
Migrating to new slug: diversify-or-bust from: /2008/02/11/diversify-or-bust/
WordPressURL: /2007/11/29/skip-between-shares-quickly/
Migrating to new slug: skip-between-shares-quickly from: /2007/11/29/skip-between-shares-quickly/
WordPressURL: /2010/07/21/report-improvements/
Migrating to new slug: report-improvements from: /2010/07/21/report-improvements/
WordPressURL: /2015/04/28/save-date-mfund-roadshow/
Migrating to new slug: save-date-mfund-roadshow from: /2015/04/28/save-date-mfund-roadshow/
WordPressURL: /2013/08/06/tips-for-becoming-a-successful-share-market-investor-tip-13/
Migrating to new slug: tips-for-becoming-a-successful-share-market-investor-tip-13 from: /2013/08/06/tips-for-becoming-a-successful-share-market-investor-tip-13/
WordPressURL: /2013/10/08/whats-in-a-logo/
Migrating to new slug: whats-in-a-logo from: /2013/10/08/whats-in-a-logo/
WordPressURL: /2013/06/25/tips-for-becoming-a-successful-share-market-investor-tip-7/
Migrating to new slug: tips-for-becoming-a-successful-share-market-investor-tip-7 from: /2013/06/25/tips-for-becoming-a-successful-share-market-investor-tip-7/
WordPressURL: /2014/04/02/earth-blogging-switching-apple-android/
Migrating to new slug: earth-blogging-switching-apple-android from: /2014/04/02/earth-blogging-switching-apple-android/
WordPressURL: /2014/09/30/new-features-custom-groupings-display-options/
Migrating to new slug: new-features-custom-groupings-display-options from: /2014/09/30/new-features-custom-groupings-display-options/
WordPressURL: /2008/08/07/calling-all-investorweb-customers/
Migrating to new slug: calling-all-investorweb-customers from: /2008/08/07/calling-all-investorweb-customers/
WordPressURL: /2013/07/24/learning-the-pitfalls-of-portfolio-mismanagement-at-an-early-age/
Migrating to new slug: learning-the-pitfalls-of-portfolio-mismanagement-at-an-early-age from: /2013/07/24/learning-the-pitfalls-of-portfolio-mismanagement-at-an-early-age/
WordPressURL: /2015/02/11/announcing-new-sharesight-strategic-partner-esuperfund-ebroking/
Migrating to new slug: announcing-new-sharesight-strategic-partner-esuperfund-ebroking from: /2015/02/11/announcing-new-sharesight-strategic-partner-esuperfund-ebroking/
WordPressURL: /2013/08/27/tips-for-becoming-a-successful-share-market-investor-tip-16/
Migrating to new slug: tips-for-becoming-a-successful-share-market-investor-tip-16 from: /2013/08/27/tips-for-becoming-a-successful-share-market-investor-tip-16/
WordPressURL: /2011/04/07/new-categorise-your-shares/
Migrating to new slug: new-categorise-your-shares from: /2011/04/07/new-categorise-your-shares/
WordPressURL: /2013/07/18/beware-all-watch-lists-and-portfolio-management-tools-are-not-created-equal/
Migrating to new slug: beware-all-watch-lists-and-portfolio-management-tools-are-not-created-equal from: /2013/07/18/beware-all-watch-lists-and-portfolio-management-tools-are-not-created-equal/
WordPressURL: /2014/01/30/a-new-partnership-with-cmc-markets/
Migrating to new slug: a-new-partnership-with-cmc-markets from: /2014/01/30/a-new-partnership-with-cmc-markets/
WordPressURL: /2008/06/06/foreign-investment-fund-taxpayers/
Migrating to new slug: foreign-investment-fund-taxpayers from: /2008/06/06/foreign-investment-fund-taxpayers/
WordPressURL: /2015/03/24/next-bank-sydney-wrap/
Migrating to new slug: next-bank-sydney-wrap from: /2015/03/24/next-bank-sydney-wrap/
WordPressURL: /2008/07/29/so-whats-it-to-be-a-dog-or-a-lame-duck/
Migrating to new slug: so-whats-it-to-be-a-dog-or-a-lame-duck from: /2008/07/29/so-whats-it-to-be-a-dog-or-a-lame-duck/
WordPressURL: /2013/09/17/the-high-price-of-investment-access/
Migrating to new slug: the-high-price-of-investment-access from: /2013/09/17/the-high-price-of-investment-access/
WordPressURL: /2015/12/08/announcing-new-partnership-republic-wealth-management/
Migrating to new slug: announcing-new-partnership-republic-wealth-management from: /2015/12/08/announcing-new-partnership-republic-wealth-management/
WordPressURL: /2014/09/01/build-will-come-xerocon-australia-2014/
Migrating to new slug: build-will-come-xerocon-australia-2014 from: /2014/09/01/build-will-come-xerocon-australia-2014/
WordPressURL: /2013/12/17/new-feature-carry-forward-loss/
Migrating to new slug: new-feature-carry-forward-loss from: /2013/12/17/new-feature-carry-forward-loss/
WordPressURL: /2014/03/16/the-improved-sharesight-interface-new-body-same-engine/
Migrating to new slug: the-improved-sharesight-interface-new-body-same-engine from: /2014/03/16/the-improved-sharesight-interface-new-body-same-engine/
WordPressURL: /2014/08/01/the-importance-of-using-a-purpose-built-application/
Migrating to new slug: the-importance-of-using-a-purpose-built-application from: /2014/08/01/the-importance-of-using-a-purpose-built-application/
WordPressURL: /2015/01/20/watch-the-self-directed-investor-fintech-expo/
Migrating to new slug: watch-the-self-directed-investor-fintech-expo from: /2015/01/20/watch-the-self-directed-investor-fintech-expo/
WordPressURL: /2012/01/24/teaching-your-kids-about-the-stock-market-part-two/
Migrating to new slug: teaching-your-kids-about-the-stock-market-part-two from: /2012/01/24/teaching-your-kids-about-the-stock-market-part-two/
WordPressURL: /2010/09/10/international-shares-manual-entry-now-available/
Migrating to new slug: international-shares-manual-entry-now-available from: /2010/09/10/international-shares-manual-entry-now-available/
WordPressURL: /2015/01/27/benchmarking-now-live-on-sharesight/
Migrating to new slug: benchmarking-now-live-on-sharesight from: /2015/01/27/benchmarking-now-live-on-sharesight/
WordPressURL: /2016/04/27/sharesight-bendigo-bank/
Migrating to new slug: sharesight-bendigo-bank from: /2016/04/27/sharesight-bendigo-bank/
WordPressURL: /2013/04/26/how-old-is-too-old-to-own-shares/
Migrating to new slug: how-old-is-too-old-to-own-shares from: /2013/04/26/how-old-is-too-old-to-own-shares/
WordPressURL: /2014/10/24/why-do-accountants-love-sharesight/
Migrating to new slug: why-do-accountants-love-sharesight from: /2014/10/24/why-do-accountants-love-sharesight/
WordPressURL: /2016/06/08/the-ten-year-gap-in-financial-services-technology/
Migrating to new slug: the-ten-year-gap-in-financial-services-technology from: /2016/06/08/the-ten-year-gap-in-financial-services-technology/
WordPressURL: /2011/09/29/is-sharesight-in-cloud-cuckoo-land/
Migrating to new slug: is-sharesight-in-cloud-cuckoo-land from: /2011/09/29/is-sharesight-in-cloud-cuckoo-land/
WordPressURL: /2008/04/22/know-your-portfolio/
Migrating to new slug: know-your-portfolio from: /2008/04/22/know-your-portfolio/
WordPressURL: /2016/05/16/sharesight-at-unit/
Migrating to new slug: sharesight-at-unit from: /2016/05/16/sharesight-at-unit/
WordPressURL: /2015/08/26/how-do-i-set-up-a-share-club/
Migrating to new slug: how-do-i-set-up-a-share-club from: /2015/08/26/how-do-i-set-up-a-share-club/
WordPressURL: /2013/05/09/new-navigation-menu/
Migrating to new slug: new-navigation-menu from: /2013/05/09/new-navigation-menu/
WordPressURL: /2014/05/12/announcing-new-strategic-partner-stockspot/
Migrating to new slug: announcing-new-strategic-partner-stockspot from: /2014/05/12/announcing-new-strategic-partner-stockspot/
WordPressURL: /2013/08/13/tips-for-becoming-a-successful-share-market-investor-tip-14/
Migrating to new slug: tips-for-becoming-a-successful-share-market-investor-tip-14 from: /2013/08/13/tips-for-becoming-a-successful-share-market-investor-tip-14/
WordPressURL: /2011/08/11/big-brother-is-watching-and-acting/
Migrating to new slug: big-brother-is-watching-and-acting from: /2011/08/11/big-brother-is-watching-and-acting/
WordPressURL: /2016/06/09/livewire-portfolio-track-the-fund-managers-picks/
Migrating to new slug: livewire-portfolio-track-the-fund-managers-picks from: /2016/06/09/livewire-portfolio-track-the-fund-managers-picks/
WordPressURL: /2011/07/29/hands-up-for-a-capital-gains-tax/
Migrating to new slug: hands-up-for-a-capital-gains-tax from: /2011/07/29/hands-up-for-a-capital-gains-tax/
WordPressURL: /2008/08/29/why-you-should-invest-in-the-share-market/
Migrating to new slug: why-you-should-invest-in-the-share-market from: /2008/08/29/why-you-should-invest-in-the-share-market/
WordPressURL: /2008/08/01/a-seriously-flawed-business-model/
Migrating to new slug: a-seriously-flawed-business-model from: /2008/08/01/a-seriously-flawed-business-model/
WordPressURL: /2015/05/08/enhanced-staff-sharing-permissions-for-pro-partners/
Migrating to new slug: enhanced-staff-sharing-permissions-for-pro-partners from: /2015/05/08/enhanced-staff-sharing-permissions-for-pro-partners/
WordPressURL: /2013/11/28/new-pro-feature-personalised-marketing-materials/
Migrating to new slug: new-pro-feature-personalised-marketing-materials from: /2013/11/28/new-pro-feature-personalised-marketing-materials/
WordPressURL: /2016/04/07/how-to-handle-the-m2-vocus-merger/
Migrating to new slug: how-to-handle-the-m2-vocus-merger from: /2016/04/07/how-to-handle-the-m2-vocus-merger/
WordPressURL: /2016/02/19/asa-conference-2016/
Migrating to new slug: asa-conference-2016 from: /2016/02/19/asa-conference-2016/
WordPressURL: /2010/01/27/excel-exports-now-available/
Migrating to new slug: excel-exports-now-available from: /2010/01/27/excel-exports-now-available/
WordPressURL: /2014/05/02/how-do-i-track-my-kiwisaver-fund/
Migrating to new slug: how-do-i-track-my-kiwisaver-fund from: /2014/05/02/how-do-i-track-my-kiwisaver-fund/
WordPressURL: /2013/05/28/tips-for-becoming-a-successful-share-market-investor-tip-3/
Migrating to new slug: tips-for-becoming-a-successful-share-market-investor-tip-3 from: /2013/05/28/tips-for-becoming-a-successful-share-market-investor-tip-3/
WordPressURL: /2015/05/28/take-budget/
Migrating to new slug: take-budget from: /2015/05/28/take-budget/
WordPressURL: /2015/01/08/sharesight-now-silver-xero-partner/
Migrating to new slug: sharesight-now-silver-xero-partner from: /2015/01/08/sharesight-now-silver-xero-partner/
WordPressURL: /2014/07/22/sharesight-integrates-macquarie-cash-management-account/
Migrating to new slug: sharesight-integrates-macquarie-cash-management-account from: /2014/07/22/sharesight-integrates-macquarie-cash-management-account/
WordPressURL: /2015/02/24/where-is-the-uber-of-australian-wealth-management/
Migrating to new slug: where-is-the-uber-of-australian-wealth-management from: /2015/02/24/where-is-the-uber-of-australian-wealth-management/
WordPressURL: /2014/11/10/what-is-unbundling-and-how-much-can-it-save-me/
Migrating to new slug: what-is-unbundling-and-how-much-can-it-save-me from: /2014/11/10/what-is-unbundling-and-how-much-can-it-save-me/
WordPressURL: /2015/08/24/global-markets-available-singapore-frankfurt-johannesburg/
Migrating to new slug: global-markets-available-singapore-frankfurt-johannesburg from: /2015/08/24/global-markets-available-singapore-frankfurt-johannesburg/
WordPressURL: /2012/04/26/product-update-notes-file-attachments-pdf-reports/
Migrating to new slug: product-update-notes-file-attachments-pdf-reports from: /2012/04/26/product-update-notes-file-attachments-pdf-reports/
WordPressURL: /2014/12/19/2014-year-review/
Migrating to new slug: 2014-year-review from: /2014/12/19/2014-year-review/
WordPressURL: /2013/03/14/meet-the-cloud-superheroes/
Migrating to new slug: meet-the-cloud-superheroes from: /2013/03/14/meet-the-cloud-superheroes/
WordPressURL: /2008/11/26/how-do-you-choose-which-shares-to-buy/
Migrating to new slug: how-do-you-choose-which-shares-to-buy from: /2008/11/26/how-do-you-choose-which-shares-to-buy/
WordPressURL: /2012/01/19/sharesight-teams-up-with-cmc-markets-stockbroking/
Migrating to new slug: sharesight-teams-up-with-cmc-markets-stockbroking from: /2012/01/19/sharesight-teams-up-with-cmc-markets-stockbroking/
WordPressURL: /2013/07/16/tips-for-becoming-a-successful-share-market-investor-tip-10/
Migrating to new slug: tips-for-becoming-a-successful-share-market-investor-tip-10 from: /2013/07/16/tips-for-becoming-a-successful-share-market-investor-tip-10/
WordPressURL: /2013/10/17/greetings-from-brisbane/
Migrating to new slug: greetings-from-brisbane from: /2013/10/17/greetings-from-brisbane/
WordPressURL: /2015/09/16/register-now-for-atsa-2015/
Migrating to new slug: register-now-for-atsa-2015 from: /2015/09/16/register-now-for-atsa-2015/
WordPressURL: /2008/11/03/when-will-the-share-market-bounce-back-and-how-high-will-it-bounce/
Migrating to new slug: when-will-the-share-market-bounce-back-and-how-high-will-it-bounce from: /2008/11/03/when-will-the-share-market-bounce-back-and-how-high-will-it-bounce/
WordPressURL: /2016/05/23/announcing-custom-groups/
Migrating to new slug: announcing-custom-groups from: /2016/05/23/announcing-custom-groups/
WordPressURL: /2014/08/25/sharesight-wins-xero-add-partner-year/
Migrating to new slug: sharesight-wins-xero-add-partner-year from: /2014/08/25/sharesight-wins-xero-add-partner-year/
WordPressURL: /2013/06/11/tips-for-becoming-a-successful-share-market-investor-tip-5/
Migrating to new slug: tips-for-becoming-a-successful-share-market-investor-tip-5 from: /2013/06/11/tips-for-becoming-a-successful-share-market-investor-tip-5/
WordPressURL: /2016/03/11/contract-notes-inbox/
Migrating to new slug: contract-notes-inbox from: /2016/03/11/contract-notes-inbox/
WordPressURL: /2012/01/12/teaching-your-kids-about-basic-financial-literacy/
Migrating to new slug: teaching-your-kids-about-basic-financial-literacy from: /2012/01/12/teaching-your-kids-about-basic-financial-literacy/
WordPressURL: /2014/02/08/why-on-earth-are-we-blogging-about-wearable-technology/
Migrating to new slug: why-on-earth-are-we-blogging-about-wearable-technology from: /2014/02/08/why-on-earth-are-we-blogging-about-wearable-technology/
WordPressURL: /2010/02/17/dividend-reinvestments/
Migrating to new slug: dividend-reinvestments from: /2010/02/17/dividend-reinvestments/
WordPressURL: /2015/10/01/select-equities-credit-suisse/
Migrating to new slug: select-equities-credit-suisse from: /2015/10/01/select-equities-credit-suisse/
WordPressURL: /2011/09/07/sharesight-for-oldies-the-young-at-heart/
Migrating to new slug: sharesight-for-oldies-the-young-at-heart from: /2011/09/07/sharesight-for-oldies-the-young-at-heart/
WordPressURL: /2016/08/31/find-missing-dividends-performance-report/
Migrating to new slug: find-missing-dividends-performance-report from: /2016/08/31/find-missing-dividends-performance-report/
WordPressURL: /2016/09/13/livewire-live-portfolio-september-2016-update/
Migrating to new slug: livewire-live-portfolio-september-2016-update from: /2016/09/13/livewire-live-portfolio-september-2016-update/
WordPressURL: /2016/08/25/track-madrid-milan-bombay-india-stock-markets/
Migrating to new slug: track-madrid-milan-bombay-india-stock-markets from: /2016/08/25/track-madrid-milan-bombay-india-stock-markets/
WordPressURL: /2016/08/24/track-drp-residual-balances/
Migrating to new slug: track-drp-residual-balances from: /2016/08/24/track-drp-residual-balances/
No wordpress url; nothing to do
No wordpress url; nothing to do
WordPressURL: /2016/07/27/how-to-get-help-within-your-sharesight-portfolio/
Migrating to new slug: how-to-get-help-within-your-sharesight-portfolio from: /2016/07/27/how-to-get-help-within-your-sharesight-portfolio/
WordPressURL: /2016/07/25/4-ways-to-maximise-returns-in-a-low-return-world/
Migrating to new slug: 4-ways-to-maximise-returns-in-a-low-return-world from: /2016/07/25/4-ways-to-maximise-returns-in-a-low-return-world/
WordPressURL: /2016/07/19/interpreting-portfolio-performance/
Migrating to new slug: interpreting-portfolio-performance from: /2016/07/19/interpreting-portfolio-performance/
WordPressURL: /2016/07/15/michael-hill-restructure/
Migrating to new slug: michael-hill-restructure from: /2016/07/15/michael-hill-restructure/
No wordpress url; nothing to do
WordPressURL: /2016/09/19/pwc-partners-with-sharesight/
Migrating to new slug: pwc-partners-with-sharesight from: /2016/09/19/pwc-partners-with-sharesight/
WordPressURL: /2015/07/28/see-you-at-atsa-2015/
Migrating to new slug: see-you-at-atsa-2015 from: /2015/07/28/see-you-at-atsa-2015/
WordPressURL: /2015/07/15/an-oral-history-of-the-chicago-board-of-trade/
Migrating to new slug: an-oral-history-of-the-chicago-board-of-trade from: /2015/07/15/an-oral-history-of-the-chicago-board-of-trade/
WordPressURL: /2015/05/19/introducing-better-date-range-selectors/
Migrating to new slug: introducing-better-date-range-selectors from: /2015/05/19/introducing-better-date-range-selectors/
WordPressURL: /2015/03/26/does-freemium-work/
Migrating to new slug: does-freemium-work from: /2015/03/26/does-freemium-work/
WordPressURL: /2014/01/23/portfolio-setup-tip-3-automatic-contract-note-processing/
Migrating to new slug: portfolio-setup-tip-3-automatic-contract-note-processing from: /2014/01/23/portfolio-setup-tip-3-automatic-contract-note-processing/
WordPressURL: /2013/10/11/sharesight-along-for-the-xero-roadshow-october-2013/
Migrating to new slug: sharesight-along-for-the-xero-roadshow-october-2013 from: /2013/10/11/sharesight-along-for-the-xero-roadshow-october-2013/
WordPressURL: /2013/09/24/letting-the-dust-settle-on-xerocon-2013/
Migrating to new slug: letting-the-dust-settle-on-xerocon-2013 from: /2013/09/24/letting-the-dust-settle-on-xerocon-2013/
WordPressURL: /2011/11/24/sharesight-making-the-most-of-the-cloud/
Migrating to new slug: sharesight-making-the-most-of-the-cloud from: /2011/11/24/sharesight-making-the-most-of-the-cloud/
WordPressURL: /2011/10/07/starting-an-smsf/
Migrating to new slug: starting-an-smsf from: /2011/10/07/starting-an-smsf/
WordPressURL: /2010/06/16/investment-outlook-by-james-cornell/
Migrating to new slug: investment-outlook-by-james-cornell from: /2010/06/16/investment-outlook-by-james-cornell/
No wordpress url; nothing to do
WordPressURL: /2015/02/26/2015-xero-roadshow-wrap-up/
Migrating to new slug: 2015-xero-roadshow-wrap-up from: /2015/02/26/2015-xero-roadshow-wrap-up/
WordPressURL: /2016/09/27/visualise-your-portfolio-with-sharesight-and-simply-wall-st/
Migrating to new slug: visualise-your-portfolio-with-sharesight-and-simply-wall-st from: /2016/09/27/visualise-your-portfolio-with-sharesight-and-simply-wall-st/
WordPressURL: /2016/09/28/track-hargreaves-lansdown-trades/
Migrating to new slug: track-hargreaves-lansdown-trades from: /2016/09/28/track-hargreaves-lansdown-trades/
WordPressURL: /2016/09/29/dont-pay-for-your-investment-data/
Migrating to new slug: dont-pay-for-your-investment-data from: /2016/09/29/dont-pay-for-your-investment-data/
```