### PR TITLE
Have the Pro Navigation `Pricing` link(s) go to an anchor instead.

### DIFF
--- a/helpers/middleman/menu.rb
+++ b/helpers/middleman/menu.rb
@@ -5,18 +5,24 @@ module MiddlemanMenuHelpers
   include MiddlemanLocaleHelpers # for current_locale_obj method
   include MiddlemanPageHelpers # for locale_page method
 
-  def get_menu_config(locale_obj: current_locale_obj)
+  def get_menu_config(locale_obj: current_locale_obj, professional: false)
     return [
-      get_features_menu(locale_obj: locale_obj),
-      get_benefits_menu(locale_obj: locale_obj),
-      get_pricing_menu(locale_obj: locale_obj),
-      get_resources_menu(locale_obj: locale_obj)
+      get_features_menu(locale_obj: locale_obj, professional: professional),
+      get_benefits_menu(locale_obj: locale_obj, professional: professional),
+      get_pricing_menu(locale_obj: locale_obj, professional: professional),
+      get_resources_menu(locale_obj: locale_obj, professional: professional)
     ]
   end
 
   private
 
-  def get_features_menu(locale_obj: current_locale_obj)
+  def get_pricing_href(locale_obj: current_locale_obj, professional: false)
+    return '#pricing' if professional
+    
+    return localize_url('pricing', locale_id: locale_obj[:id])
+  end
+
+  def get_features_menu(locale_obj: current_locale_obj, professional: false)
     return {
       label: 'Features',
       rows: [
@@ -83,7 +89,7 @@ module MiddlemanMenuHelpers
                   visible_desktop: false,
                   label: 'Pricing',
                   icon: 'wallet',
-                  href: localize_url('pricing', locale_id: locale_obj[:id]),
+                  href: get_pricing_href(locale_obj: locale_obj, professional: professional), # this goes to an anchor for pro
                   title: locale_page(page: 'pricing', locale_obj: locale_obj)[:page_title],
                 },
                 {
@@ -111,7 +117,7 @@ module MiddlemanMenuHelpers
     }
   end
 
-  def get_benefits_menu(locale_obj: current_locale_obj)
+  def get_benefits_menu(locale_obj: current_locale_obj, professional: false)
     return {
       label: 'Benefits',
       rows: [
@@ -156,17 +162,16 @@ module MiddlemanMenuHelpers
     }
   end
 
-  def get_pricing_menu(locale_obj: current_locale_obj)
-
+  def get_pricing_menu(locale_obj: current_locale_obj, professional: false)
     return {
       visible_mobile: false,
       label: 'Pricing',
-      href: localize_url('pricing', locale_id: locale_obj[:id]),
+      href: get_pricing_href(locale_obj: locale_obj, professional: professional), # this goes to an anchor for pro
       title: locale_page(page: 'pricing', locale_obj: locale_obj)[:page_title],
     }
   end
 
-  def get_resources_menu(locale_obj: current_locale_obj)
+  def get_resources_menu(locale_obj: current_locale_obj, professional: false)
     return {
       label: 'Resources',
       class: 'menu--lg',

--- a/mappers/landing-pages/page.rb
+++ b/mappers/landing-pages/page.rb
@@ -12,12 +12,14 @@ class LandingPagesPageMapper < ContentfulMiddleman::Mapper::Base
         case layout
         when 'default'
           'layout'
-        when 'index'
-          'layout_index'
-        when 'pro'
-          'layout_pro'
-        when 'blog_post'
-          'blog_post'
+        # NOTE: We don't actually support anything by 'default' here! 
+        # Content Model: https://app.contentful.com/spaces/cbgsdqa84fjb/content_types/page/fields
+        # when 'index'
+        #   'layout_index'
+        # when 'pro'
+        #   'layout_pro'
+        # when 'blog_post'
+        #   'blog_post'
         else
           layout
         end

--- a/source/page-pro.html.erb
+++ b/source/page-pro.html.erb
@@ -32,7 +32,7 @@ layout: layout_pro
     </div>
   </div>
 
-  <div class="layout layout_alternate">
+  <div class="layout layout_alternate" id="pricing">
     <div class="layout_primary">
       <h2 class="heading heading_paragraph">Simple pricing, no commitment</h2>
       <p>

--- a/source/partials/header/_navigation.html.erb
+++ b/source/partials/header/_navigation.html.erb
@@ -12,7 +12,7 @@
 <%
   # We store this menu data in here to be used for both Desktop and Mobile navigation..
   locale_obj = locals[:locale_obj] || current_locale_obj
-  menus = get_menu_config(locale_obj: locale_obj)
+  menus = get_menu_config(locale_obj: locale_obj, professional: locals[:professional])
 %>
 
 <div class="container nav__container">

--- a/spec/helpers/middleman/menu_spec.rb
+++ b/spec/helpers/middleman/menu_spec.rb
@@ -63,6 +63,43 @@ describe 'Menu Helper', :type => :helper do
       expect(menus[3][:label]).to eq('Resources')
     end
 
+    it "should have a different link when professional=true" do
+      menus = @app.get_menu_config()
+      menus_pro = @app.get_menu_config(professional: true)
+
+      ####
+      # Desktop Item
+      regular_menu = menus[2]
+      pro_menu = menus_pro[2]
+      expect(regular_menu[:label]).to eq('Pricing')
+      expect(regular_menu[:visible_mobile]).to eq(false)
+      expect(pro_menu[:label]).to eq('Pricing')
+      expect(pro_menu[:visible_mobile]).to eq(false)
+
+      # Labels are as expected
+      expect(regular_menu[:href]).to end_with('/pricing/')
+      expect(pro_menu[:href]).to eq('#pricing')
+      expect(pro_menu[:href]).not_to eq(regular_menu[:href]) # don't match
+      # End Desktop
+      ####
+
+      ####
+      # Mobile Item
+      regular_menu = menus[0][:rows][1][:columns][0][:links][0]
+      pro_menu = menus_pro[0][:rows][1][:columns][0][:links][0]
+      expect(regular_menu[:label]).to eq('Pricing')
+      expect(regular_menu[:visible_desktop]).to eq(false)
+      expect(pro_menu[:label]).to eq('Pricing')
+      expect(pro_menu[:visible_desktop]).to eq(false)
+
+      # Labels are as expected
+      expect(regular_menu[:href]).to end_with('/pricing/')
+      expect(pro_menu[:href]).to eq('#pricing')
+      expect(pro_menu[:href]).not_to eq(regular_menu[:href]) # don't match
+      # End Desktop
+      ####
+    end
+
     # NOTE: This does also test global, because it has no "path" or "country" differences.
     Capybara.app.data.locales.each do |locale_obj|
       it "#{locale_obj[:country]} should have an expected pricing link" do


### PR DESCRIPTION
[Vimaly Story](https://vimaly.com/#j8mqm/t/On_the_Pro_Page,_Pricing_should_not_direct_to_reta.../Ec5cCTJICn6Bv87hX)

Sends to the `#pricing` anchor instead.

:warning: This would have applied if we have a Landing Page on the pro layout, so I confirmed we can remove that layout and commented it out.