### PR TITLE
Add back in hreflangs from sitemap (which caused duplicate links).

### DIFF
--- a/source/sitemap.xml.erb
+++ b/source/sitemap.xml.erb
@@ -41,9 +41,9 @@
 
     <% data.locales.each do |locale| %>
       <% if locale[:id] == default_locale_id %>
-        <xhtml:link rel="alternate" href="<%= localize_url(category[:path], locale_id: locale[:id]) %>" />
+        <xhtml:link rel="alternate" href="<%= localize_url(category[:path], locale_id: locale[:id]) %>" hreflang="x-default" />
       <% end %>
-      <xhtml:link rel="alternate" href="<%= localize_url(category[:path], locale_id: locale[:id]) %>" />
+      <xhtml:link rel="alternate" href="<%= localize_url(category[:path], locale_id: locale[:id]) %>" hreflang="<%= locale[:lang].downcase %>" />
     <%end%>
   </url>
 <% end %>
@@ -59,9 +59,9 @@
 
     <% data.locales.each do |locale| %>
       <% if locale[:id] == default_locale_id %>
-        <xhtml:link rel="alternate" href="<%= partner_url(partner, locale_id: locale[:id]) %>" />
+        <xhtml:link rel="alternate" href="<%= partner_url(partner, locale_id: locale[:id]) %>" hreflang="x-default" />
       <% end %>
-      <xhtml:link rel="alternate" href="<%= partner_url(partner, locale_id: locale[:id]) %>" />
+      <xhtml:link rel="alternate" href="<%= partner_url(partner, locale_id: locale[:id]) %>" hreflang="<%= locale[:lang].downcase %>" />
     <%end%>
   </url>
 <%end%>
@@ -78,9 +78,9 @@
 
     <% data.locales.each do |locale| %>
       <% if locale[:id] == default_locale_id %>
-        <xhtml:link rel="alternate" href="<%= landing_page_url(landing_page, locale_id: locale[:id]) %>" />
+        <xhtml:link rel="alternate" href="<%= landing_page_url(landing_page, locale_id: locale[:id]) %>" hreflang="x-default" />
       <% end %>
-      <xhtml:link rel="alternate" href="<%= landing_page_url(landing_page, locale_id: locale[:id]) %>" />
+      <xhtml:link rel="alternate" href="<%= landing_page_url(landing_page, locale_id: locale[:id]) %>" hreflang="<%= locale[:lang].downcase %>" />
     <%end%>
   </url>
 <%end%>
@@ -97,9 +97,9 @@
     <% alternative_locales.each do |locale| %>
       <%# Set a default language alternate link in addition to the en-* versions we have %>
       <% if locale[:id] == default_locale_id %>
-        <xhtml:link rel="alternate" href="<%= localize_url(page_data.page, locale_id: locale[:id]) %>"/>
+        <xhtml:link rel="alternate" href="<%= localize_url(page_data.page, locale_id: locale[:id]) %>" hreflang="x-default" />
       <% end %>
-      <xhtml:link rel="alternate" href="<%= localize_url(page_data.page, locale_id: locale[:id]) %>"/>
+      <xhtml:link rel="alternate" href="<%= localize_url(page_data.page, locale_id: locale[:id]) %>" hreflang="<%= locale[:lang].downcase %>" />
     <% end %>
   </url>
 <% end %>


### PR DESCRIPTION
This reverts commit a61305b431eb556e8646b1b1f0a837fdb167a43f.

See: https://vimaly.com/#j8mqm/t/Add_back_in_hreflangs_to_our_sitemap/29zVwXV9Gblgyu9Hb, we believe that this resulted in duplicate sitemap entries as well as ruining our US Locale.

1. We should've not had duplicate links in the Sitemap.
2. Ben and Kylor don't really agree with Jaywing's advice.