### PR TITLE
Do not set a Global locale cookie on load.

### DIFF
--- a/source/js/localization.js.es6
+++ b/source/js/localization.js.es6
@@ -6,32 +6,32 @@
 //= require "./helpers/url"
 
 const localization = {
-  requestedLocaleId: "global",
+  requestedLocaleId: 'global',
   setLocaleId: false,
 
-  onLoad () {
-    this.initializeRequestedLocaleId()
-    this.ensureCookie()
-    this.initializeRegionSelector()
-    this.modifyContent()
-    this.renderLocaleNotification()
+  onLoad() {
+    this.initializeRequestedLocaleId();
+    this.ensureCookie();
+    this.initializeRegionSelector();
+    this.modifyContent();
+    this.renderLocaleNotification();
   },
 
-  isGlobalOnlyPage () {
+  isGlobalOnlyPage() {
     // NOTE: Could look in `locales.json` (via config.locales) to see if the current path is global.
-    if (window.location.pathname.indexOf('/team') === 0) return true
-    if (window.location.pathname.indexOf('/blog') === 0) return true
-    if (window.location.pathname.indexOf('/survey-thanks') === 0) return true
-    if (document.getElementById('_404')) return true
-    return false
+    if (window.location.pathname.indexOf('/team') === 0) return true;
+    if (window.location.pathname.indexOf('/blog') === 0) return true;
+    if (window.location.pathname.indexOf('/survey-thanks') === 0) return true;
+    if (document.getElementById('_404')) return true;
+    return false;
   },
 
-  modifyContent () {
-    this.updateUrls()
-    contentManager.updateContent()
+  modifyContent() {
+    this.updateUrls();
+    contentManager.updateContent();
   },
 
-  renderLocaleNotification () {
+  renderLocaleNotification() {
     const viewedCountry = urlHelper.getLocalisationFromPath();
     const cookieCountry = localeHelper.getCookieLocale();
 
@@ -46,17 +46,26 @@ const localization = {
 
       // change current country label, just incase it differs (should match the initial render)
       viewedCountryLabel.textContent = viewedCountryLocale.adjective;
-      cookieCountryLink.setAttribute('title', `stay on the ${viewedCountryLocale.adjective} site`);
+      cookieCountryLink.setAttribute(
+        'title',
+        `stay on the ${viewedCountryLocale.adjective} site`
+      );
 
       // change the cookie country link, title, and text
       cookieCountryLink.textContent = `return to the ${cookieCountryLocale.adjective} site`;
-      cookieCountryLink.setAttribute('title', `return to the ${cookieCountryLocale.adjective} site`);
-      cookieCountryLink.href = urlHelper.localizePath(window.location.pathname, cookieCountry);
+      cookieCountryLink.setAttribute(
+        'title',
+        `return to the ${cookieCountryLocale.adjective} site`
+      );
+      cookieCountryLink.href = urlHelper.localizePath(
+        window.location.pathname,
+        cookieCountry
+      );
 
       // show banner
       countryBanner.style.display = 'flex';
 
-      viewedCountryLink.addEventListener('click', (event) => {
+      viewedCountryLink.addEventListener('click', event => {
         // overwrite the cookie
         cookieManager.setCookie(viewedCountry);
 
@@ -69,28 +78,38 @@ const localization = {
     }
   },
 
-  setLocale (locale_id, force = false) {
-    if (!locale_id || typeof locale_id !== 'string' || !localeHelper.isValidLocaleId(locale_id)) {
-      locale_id = config.default_locale_id
+  setLocale(locale_id, force = false) {
+    if (
+      !locale_id ||
+      typeof locale_id !== 'string' ||
+      !localeHelper.isValidLocaleId(locale_id)
+    ) {
+      locale_id = config.default_locale_id;
     }
 
-    locale_id = locale_id.toLowerCase()
+    locale_id = locale_id.toLowerCase();
 
-    this.setLocaleId = locale_id
+    this.setLocaleId = locale_id;
     if (force || cookieManager.getCookie().length == 0) {
-      cookieManager.setCookie(locale_id)
+      cookieManager.setCookie(locale_id);
     }
-    this.modifyContent()
+    this.modifyContent();
   },
 
-  redirectToLocale (locale_id) {
+  redirectToLocale(locale_id) {
     // if we're not on a page that begins with the current locale, which should be localized, refresh the page and Cloudfront's localization should kick in
-    if (!this.isGlobalOnlyPage() && window.location.pathname.indexOf(`/${locale_id}`) !== 0) {
-      window.location.href = urlHelper.localizePath(window.location.pathname, locale_id);
+    if (
+      !this.isGlobalOnlyPage() &&
+      window.location.pathname.indexOf(`/${locale_id}`) !== 0
+    ) {
+      window.location.href = urlHelper.localizePath(
+        window.location.pathname,
+        locale_id
+      );
     }
   },
 
-  getCurrentLocaleId () {
+  getCurrentLocaleId() {
     if (this.setLocaleId) {
       return this.setLocaleId;
     }
@@ -98,75 +117,82 @@ const localization = {
     return urlHelper.getLocalisationFromPath();
   },
 
-  updateUrls () {
-    const localeId = this.isGlobalOnlyPage() ? localeHelper.getCookieLocale() : urlHelper.getLocalisationFromPath();
-    ;[].concat.apply([], // flatten arrays of arrays
-      [
-        config.base_url, // absolute urls (www.sharesight.com)
-        config.help_url, // help site (help.sharesight.com)
-        `${config.base_path}/`.replace(/\/+/g, '/'), // relative urls (/faq); replace duplicate slashes
-      ].map(path => Array.from(document.querySelectorAll(`a[href^="${path}"]`)))
-    ).forEach((element) => {
-      if (element.hasAttribute('data-no-localize')) return; // don't localize urls with no-localize
-      if (!urlHelper.shouldLocalizeUrl(element.href, localeId)) return; // don't localize
+  updateUrls() {
+    const localeId = this.isGlobalOnlyPage()
+      ? localeHelper.getCookieLocale()
+      : urlHelper.getLocalisationFromPath();
+    [].concat
+      .apply(
+        [], // flatten arrays of arrays
+        [
+          config.base_url, // absolute urls (www.sharesight.com)
+          config.help_url, // help site (help.sharesight.com)
+          `${config.base_path}/`.replace(/\/+/g, '/'), // relative urls (/faq); replace duplicate slashes
+        ].map(path =>
+          Array.from(document.querySelectorAll(`a[href^="${path}"]`))
+        )
+      )
+      .forEach(element => {
+        if (element.hasAttribute('data-no-localize')) return; // don't localize urls with no-localize
+        if (!urlHelper.shouldLocalizeUrl(element.href, localeId)) return; // don't localize
 
-      element.pathname = urlHelper.localizePath(element.pathname, localeId)
-    })
+        element.pathname = urlHelper.localizePath(element.pathname, localeId);
+      });
   },
 
-  getRegionSelectorNode () {
-    if (this.regionSelector) return this.regionSelector
-    this.regionSelector = document.getElementById('region_selector')
-    return this.regionSelector
+  getRegionSelectorNode() {
+    if (this.regionSelector) return this.regionSelector;
+    this.regionSelector = document.getElementById('region_selector');
+    return this.regionSelector;
   },
 
-  initializeRequestedLocaleId () {
-    this.requestedLocaleId = urlHelper.getLocalisationFromPath()
+  initializeRequestedLocaleId() {
+    this.requestedLocaleId = urlHelper.getLocalisationFromPath();
   },
 
-  ensureCookie () {
-    if (cookieManager.getCookie().length > 0) return
-    this.setLocale(this.requestedLocaleId)
+  ensureCookie() {
+    if (cookieManager.getCookie().length > 0) return;
+    this.setLocale(this.requestedLocaleId);
   },
 
-  initializeRegionSelector () {
-    const self = this
+  initializeRegionSelector() {
+    const self = this;
     const selector = this.getRegionSelectorNode();
-    if (!selector || !selector.options || !selector.options.length) return
+    if (!selector || !selector.options || !selector.options.length) return;
 
-    this.setRegionSelectorValue()
+    this.setRegionSelectorValue();
     this.setCookieFromRegionSelector();
 
     // when it changes, set locale
     selector.onchange = function () {
       self.setLocale(this.value, true);
       self.redirectToLocale(this.value);
-    }
+    };
   },
 
-  setRegionSelectorValue () {
+  setRegionSelectorValue() {
     const selector = this.getRegionSelectorNode();
     if (!selector) return;
-    if (selector.value === localeHelper.getCookieLocale()) return // nothing to change then
+    if (selector.value === localeHelper.getCookieLocale()) return; // nothing to change then
 
     // set the region selector to match the current locale on unlocalized pages
     Array.from(selector.options).forEach(option => {
-      option.removeAttribute('selected')
+      option.removeAttribute('selected');
 
       if (option.value.toLowerCase() === localeHelper.getCookieLocale()) {
-        option.setAttribute('selected', true)
+        option.setAttribute('selected', true);
       }
-    })
+    });
   },
 
-  setCookieFromRegionSelector () {
-    const selector = this.getRegionSelectorNode()
-    if (selector.value === config.default_locale_id) return // don't set a global cookie when the page loads
-    this.setLocale(selector.value)
+  setCookieFromRegionSelector() {
+    const selector = this.getRegionSelectorNode();
+    if (selector.value === config.default_locale_id) return; // don't set a global cookie when the page loads
+    this.setLocale(selector.value);
   },
-}
+};
 
-;(function() {
+(function () {
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => {
       localization.onLoad();


### PR DESCRIPTION
Relevant Story: [Vimaly](https://vimaly.com/#j8mqm/t/www-gatsby_Cloudfront_should_be_the_source-of-trut.../7LRBCQznPRjftlAKf)

As per [BEHAVIOUR.md](https://github.com/sharesight/www.sharesight.com/blob/master/BEHAVIOUR.md), this should be our behavior, but we broke this somewhere along the way…I guess?

Loading up `/blog/` or `/team/` would set your `sharesight_country=global`, so if you then went to `/pricing/`, you would see global pricing rather than `/nz/` pricing…

- Auto-formatted in 3b1076b9 (feel free to ignore that commit…that's just VSCode + Prettier).
- Several whacks at "don't set a cookie if it's global…unless it's being forced".
- Removes this `requestedLocaleId` caching…a few too many lines of code for something we only use once–might as well do it in that file.
- Adding some documentation and brief cleanup while I'm here…
