### PR TITLE
Just have `<dt><dd>` full-width in mobile to fit better.

### DIFF
--- a/source/css/partners/pages/_individual.scss
+++ b/source/css/partners/pages/_individual.scss
@@ -123,19 +123,9 @@ $__logo_height--sm: 110px;
       padding: $gutter;
       background: $background_offset_white;
 
-      @include respond-to(sm, max) {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-      }
-
       dt, dd {
-        display: inline-block;
+        display: block;
         margin: 0;
-
-        @include respond-to(sm, max) {
-          width: 50%;
-        }
       }
 
       dt {
@@ -147,15 +137,8 @@ $__logo_height--sm: 110px;
           margin-top: $gutter;
 
           @include respond-to(sm, max) {
-            &, & ~ dd {
-              margin-top: $gutter;
-            }
+            margin-top: $gutter/2;
           }
-        }
-
-        @include respond-to(md, min) {
-          display: block;
-          margin-right: 0;
         }
       }
 


### PR DESCRIPTION
Story: https://vimaly.com/#j8mqm/t/wwwPartner_Directory_Email_address_outside_bounds_.../lZZ4a2teOt8THCxzx

No real reason to have them flex/50% width in mobile; probably just worked for the partners we had 3-4 years ago, but some emails just don't fit.

Example:
 - https://www.sharesight.com/partners/affluence-funds-management/ (mobile overflows)
 - https://staging-www.sharesight.com/partners/affluence-funds-management/ (fixed)