### PR TITLE
Change 'Your Obligations' to 'Your obligations'

### DIFF
--- a/source/page-sharesight-terms-of-use.html.erb
+++ b/source/page-sharesight-terms-of-use.html.erb
@@ -33,7 +33,7 @@ section_class: 'section_default'
           </ol>
         </li>
 
-        <li>Your Obligations
+        <li>Your obligations
           <ol>
             <li>
               You may only access and use Sharesight to manage your personal portfolios and you are responsible for all activity on your account.


### PR DESCRIPTION
Adjust casing to be consistent with other section headers and pro terms of use page (pro terms has 'Your obligations').
[Vimaly story](https://vimaly.com/#j8mqm/t/wwwTerms_of_Use_Capitalisation_typo_in_Your_Obliga.../qiQb845r0KtrjAhNA)

(This change was discussed with and approved by Ben)