### PR TITLE
Try linking to a sitemap generated by Gatsby so we have awareness of those pages.

### DIFF
--- a/source/sitemapindex.xml.erb
+++ b/source/sitemapindex.xml.erb
@@ -2,8 +2,15 @@
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <% data.locales.each do |locale| %>
     <sitemap>
-      <loc><%= localize_url('/sitemap.xml', locale_id: locale[:id] )%></loc>
-      <lastmod><%= Time.now.utc.iso8601 %></lastmod>
+      <loc><%= localize_url('/sitemap.xml', locale_id: locale[:id]) %></loc>
+    </sitemap>
+
+    <%
+     # We inject a sitemap from Gatsby from the code at https://www.github.com/sharesight/static-www
+     # NOTE: This will not be available locally in development…I have no solution for you.
+    %>
+    <sitemap>
+      <loc><%= localize_url('/gatsby/sitemap-index.xml', locale_id: locale[:id]) %></loc>
     </sitemap>
   <% end %>
 </sitemapindex>


### PR DESCRIPTION
Vimaly Story: https://vimaly.com/#j8mqm/t/NOTE:_Sitemaps_are_still_managed_by_Middleman/u5sJGVizHfwtgmxr7
Gatsby PR: https://github.com/sharesight/static-www/pull/214

---

Points to a sitemap from the above PR.

This would allow us to remove pages from this repo while still having them in the other repo, without disrupting our sitemaps…in theory.