### PR TITLE
Robots.txt: disallow the referral terms and conditions page.

### DIFF
--- a/source/robots.txt.erb
+++ b/source/robots.txt.erb
@@ -17,7 +17,12 @@ Disallow: <%= localize_path(locale_page[:page], locale_id: locale[:id]) %>
 <% end %>
 
 <% data.locales.each do |locale| %>
-Disallow: <%= localize_path('/404', locale_id: locale[:id] )%>
+Disallow: <%= localize_path('/404', locale_id: locale[:id]) %>
+
+<%# Disallow a hardcoded list of pages (external to this repo) %>
+<% ['/referral-terms-and-conditions'].each do |disallow_page| %>
+Disallow: <%= localize_path(disallow_page, locale_id: locale[:id]) %>
+<% end %>
 <% end %>
 
 Sitemap: <%= base_url('/sitemapindex.xml') %>

--- a/spec/features/robots_spec.rb
+++ b/spec/features/robots_spec.rb
@@ -12,6 +12,7 @@ describe 'Sitemap', :type => :feature do
 
     locales.each do |locale|
       expect(page).to have_text("Disallow: #{localize_path('/404', locale_id: locale[:id])}")
+      expect(page).to have_text("Disallow: #{localize_path('/referral-terms-and-conditions', locale_id: locale[:id])}")
 
       expect(page).to have_text("Sitemap: #{localize_url('/gatsby/sitemap-index.xml', locale_id: locale[:id])}")
       expect(page).to have_text("Sitemap: #{localize_url('/sitemap.xml', locale_id: locale[:id])}")


### PR DESCRIPTION
These pages are no longer maintained in this repo, but instead in Gatsby, so we need to manually disallow them.

@jenniferexong I just based this off of your PR, please check it out…I think it works!