### PR TITLE
Removing references to investment-portfolio-performance page

### DIFF
--- a/helpers/middleman/menu.rb
+++ b/helpers/middleman/menu.rb
@@ -36,7 +36,7 @@ module MiddlemanMenuHelpers
                   icon_hover: 'chart-line-up-bold',
                   label: 'Performance',
                   href: localize_path('investment-portfolio-performance', locale_id: locale_obj[:id]),
-                  title: locale_page(page: 'investment-portfolio-performance', locale_obj: locale_obj)[:page_title],
+                  title: "Investment Portfolio Performance | #{locale_obj[:append_title]}",
                 },
                 {
                   icon: 'coin',


### PR DESCRIPTION
The ticket can be found [here](https://vimaly.com/#j8mqm/t/www_Remove_performance_page/Wxmz71uvTJomTk47i)

Removing this page so we can see the new gatsby one!