### PR TITLE
Removing references to the middleman pages - Updating tests for events, faq, affiliates

### DIFF
--- a/spec/features/external_sanity_spec.rb
+++ b/spec/features/external_sanity_spec.rb
@@ -4,10 +4,7 @@ describe 'External Link Sanity', type: :feature do
   it 'should return a valid page for hard coded links' do
     [
       'reviews',
-      'affiliates',
-      'events',
       'become-a-partner',
-      'faq'
     ].each do |path|
       visit path
       expect(page).to respond_successfully


### PR DESCRIPTION
Missed removing these tests in the previous PRs #348 #350 #351 - it currently fails on the events page and will likely fail for the faq and affiliates! 