### PR TITLE
Removing references to investors page in middleman

### DIFF
--- a/helpers/middleman/menu.rb
+++ b/helpers/middleman/menu.rb
@@ -129,7 +129,7 @@ module MiddlemanMenuHelpers
                 {
                   icon: 'user',
                   label: 'Investors',
-                  title: locale_page(page: 'investors', locale_obj: locale_obj)[:page_title],
+                  title: "Investors | #{locale_obj[:append_title]}",
                   href: localize_url('investors', locale_id: locale_obj[:id]),
                   description: 'Join **300,000+** investors who track their portfolios with Sharesight.',
                 },


### PR DESCRIPTION
Global search for the word 'investors' only showed one place that needed to be updated. 

See ticket [here](https://vimaly.com/#j8mqm/t/www_Remove_investors_page_from_middleman/p0dZpEAzxU6drB5mz). 

The investors page that has been created in gatsby is ready to ship but has not been merged yet. Just getting this PR ready so it can be tested and merged shortly **after** the investors page is deployed. 

[Investors Page PR. ](https://github.com/sharesight/static-www/pull/318)
[Investors Page ticket.](https://vimaly.com/#j8mqm/t/www_Rebuild_Investors_/69DCkbpSZSm7ZBHKO)