### PR TITLE
Removing references to become a partner page

### DIFF
--- a/helpers/middleman/menu.rb
+++ b/helpers/middleman/menu.rb
@@ -150,7 +150,7 @@ module MiddlemanMenuHelpers
                 {
                   icon: 'buildings',
                   label: 'Finance Companies',
-                  title: locale_page(page: 'become-a-partner', locale_obj: locale_obj)[:page_title],
+                  title: "Partner with Sharesight | #{locale_obj[:append_title]}",
                   href: localize_url('become-a-partner', locale_id: locale_obj[:id]),
                   description: 'Connect with Sharesight to power your business.'
                 }
@@ -224,7 +224,7 @@ module MiddlemanMenuHelpers
                 {
                   icon: 'handshake',
                   label: 'Become a Partner',
-                  title: locale_page(page: 'become-a-partner', locale_obj: locale_obj)[:page_title],
+                  title: "Partner with Sharesight | #{locale_obj[:append_title]}",
                   href: localize_url('become-a-partner', locale_id: locale_obj[:id]),
                 },
                 {

--- a/source/partials/_site_footer.html.erb
+++ b/source/partials/_site_footer.html.erb
@@ -19,7 +19,7 @@
     'Partners' => [
       { name: 'Sharesight Pro', page: 'pro' },
       { name: 'Partner Directory', page: 'partners' },
-      { name: 'Become a Partner', href: 'become-a-partner', title: "Partner with Sharesight | #{locale_obj[:append_title]}" },
+      { name: 'Become a Partner', href:localize_url('become-a-partner', locale_id: locale_obj[:id]), title: "Partner with Sharesight | #{locale_obj[:append_title]}" },
       { name: 'Become an Affiliate', href: localize_url('affiliates', locale_id: locale_obj[:id]), title: "Affiliates | #{locale_obj[:append_title]}" },
       { name: 'Sharesight API', href: config[:api_url], title: 'Sharesight API Documentation' },
       { name: 'sales@sharesight.com', href: 'mailto:sales@sharesight.com', title: 'Email the Sales & Partnerships Team' },

--- a/source/partials/_site_footer.html.erb
+++ b/source/partials/_site_footer.html.erb
@@ -19,7 +19,7 @@
     'Partners' => [
       { name: 'Sharesight Pro', page: 'pro' },
       { name: 'Partner Directory', page: 'partners' },
-      { name: 'Become a Partner', page: 'become-a-partner' },
+      { name: 'Become a Partner', href: 'become-a-partner', title: "Partner with Sharesight | #{locale_obj[:append_title]}" },
       { name: 'Become an Affiliate', href: localize_url('affiliates', locale_id: locale_obj[:id]), title: "Affiliates | #{locale_obj[:append_title]}" },
       { name: 'Sharesight API', href: config[:api_url], title: 'Sharesight API Documentation' },
       { name: 'sales@sharesight.com', href: 'mailto:sales@sharesight.com', title: 'Email the Sales & Partnerships Team' },

--- a/source/partners/partials/_paginated_header.html.erb
+++ b/source/partners/partials/_paginated_header.html.erb
@@ -36,7 +36,7 @@
   <a
     href="<%= localize_url('become-a-partner', locale_id: locale_obj[:id]) %>"
     class="partners-header__become-a-partner"
-    title="<%= locale_page(page: 'become-a-partner', locale_obj: locale_obj)[:page_title] %>"
+    title="Partner with Sharesight | <%= locale_obj[:append_title] %>"
   >
     Become a Partner
   </a>


### PR DESCRIPTION
Removing references to the become a partner page. You can find the vimaly ticket [here](https://vimaly.com/#j8mqm/t/Removing_references_to_Become_a_Partner_page/dncgHfhwsTORZdm7H). 