### PR TITLE
Fixing failing test in prod

### DIFF
--- a/spec/features/external_sanity_spec.rb
+++ b/spec/features/external_sanity_spec.rb
@@ -4,7 +4,6 @@ describe 'External Link Sanity', type: :feature do
   it 'should return a valid page for hard coded links' do
     [
       'reviews',
-      'become-a-partner',
     ].each do |path|
       visit path
       expect(page).to respond_successfully


### PR DESCRIPTION
Fixing the [failing test in prod ](https://github.com/sharesight/www.sharesight.com/commit/babb4317c1d1f2e5b77c727ad3c7e02d99d7f1a4/checks)and staging by removing the 'become-a-partner' test `it 'should return a valid page for hard coded links'`  from  the external sanity spec because it's no longer hardcoded in this repo.