### PR TITLE
Update the `nokogiri` gem from 1.13.4 to 1.13.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,7 +319,7 @@ GEM
     minitest (5.14.2)
     multi_json (1.15.0)
     netrc (0.11.0)
-    nokogiri (1.13.4)
+    nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     optimist (3.0.1)


### PR DESCRIPTION
In order to handle security issues:
 - CVE-2022-29181
 - GHSA-xh29-r2w5-wx8m
 - GHSA-cgx6-hpwq-fhv5

According to their changelog those patches are only internal changes without any breaking changes.