### PR TITLE
Ignore `rack` CVEs

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -7,3 +7,7 @@ ignore:
  - CVE-2020-8165
  - CVE-2020-8184
  - CVE-2020-14001
+ - CVE-2022-30123
+ - GHSA-wq4h-7r42-5hrr
+ - CVE-2022-30122
+ - GHSA-hxqx-xwvh-44m2


### PR DESCRIPTION
Ignore these `rack` CVEs because we cannot upgrade Middleman:
 - CVE-2022-30123
 - GHSA-wq4h-7r42-5hrr
 - CVE-2022-30122
 - GHSA-hxqx-xwvh-44m2

We did this in [Investapp](https://github.com/sharesight/investapp/pull/10481), but this is a local, development dependency and we are too far off the version to bump.