### PR TITLE
Remove Bugsnag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
       run: bundle exec rspec spec -p --format d
 
 
-    # -------- Deploy to S3 ++ Notify Bugsnag and Github Deployment of Status
+    # -------- Deploy to S3 and notify Github Deployment of Status
     - name: Update deployment status to pending
       # NOTE: Only for deployment events, not commits/etc (which don't have an external deployment context)
       uses: 'deliverybot/deployment-status@v1.1.1'
@@ -91,21 +91,7 @@ jobs:
     - name: Deploy to S3
       if: success() && steps.env.outputs.should_deploy == 'true'
       run: bundle exec middleman s3_sync
-    - name: Notify Bugsnag of Released Code
-      if: success() && steps.env.outputs.should_deploy == 'true'
-      run: |
-        curl https://build.bugsnag.com/ \
-          --header "Content-Type: application/json" \
-          --data '{
-            "apiKey": ${{ secrets.BUGSNAG_API_KEY }},
-            "releaseStage": ${{ steps.env.outputs.app_env }},
-            "builderName": "Github Actions",
-            "sourceControl": {
-              "provider": "github",
-              "repository": ${{ github.repository }},
-              "revision": ${{ github.sha }}
-            }
-          }'
+
     - name: Update deployment status to success
       # NOTE: Only for deployment events, not commits/etc (which don't have an external deployment context)
       if:  github.event_name == 'deployment' && success() && steps.env.outputs.should_deploy == 'true'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,10 +13,6 @@ module ApplicationConfig
     APP_ID = 'tv6jsyee'
   end
 
-  module Bugsnag
-    API_KEY = ENV['BUGSNAG_API_KEY']
-  end
-
   module AddThis
     ID = 'ra-5b7e0717fea453d4'
   end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -13,10 +13,6 @@ module ApplicationConfig
     APP_ID = 't2bi7urt'
   end
 
-  module Bugsnag
-    API_KEY = ENV['BUGSNAG_API_KEY']
-  end
-
   module AddThis
     ID = 'ra-5b7f54d2f27cd7c1'
   end

--- a/source/layouts/partials/_analytics_js.html.erb
+++ b/source/layouts/partials/_analytics_js.html.erb
@@ -3,20 +3,6 @@
   # For JS that should be appended to the <body>, use `./_body_js.html.erb`
 %>
 
-<% if ApplicationConfig.const_defined?(:Bugsnag) && ApplicationConfig::Bugsnag::API_KEY %>
-  <!-- Bugsnag -->
-  <script src="https://d2wy8f7a9ursnm.cloudfront.net/bugsnag-3.min.js"
-    data-apikey='<%= ApplicationConfig::Bugsnag::API_KEY %>'></script>
-
-  <script>
-    if (typeof Bugsnag !== 'undefined') {
-      Bugsnag.releaseStage = '<%= env_name %>';
-      Bugsnag.notifyReleaseStages = ["production", "staging", "testing"];
-    }
-  </script>
-  <!-- End Bugsnag -->
-<% end %>
-
 <% if ApplicationConfig.const_defined?(:GoogleAnalytics) && ApplicationConfig::GoogleAnalytics::TAG_MANAGER_CONTAINER %>
   <script> // Google Tag Manager
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
We haven't had any Bugsnags in the past 60 days so it's either that this isn't working correctly or it's not valid.  Given we don't actively maintain this and we're cleaning up Bugsnag, we should clean this up.

The Github Action which sent releases appeared to no longer be working as the last one was >2 years old.  The
`secrets.BUGSNAG_API_KEY`  and the Bugsnag project itself should be deleted.

We may however want Bugsnag in the new Gatsby website as it uses JavaScript a lot more!